### PR TITLE
Added setup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+setup:
+	python -m pip install --upgrade pip poetry
+	poetry install
+
 publish:
 	rm -rf dist
 	git checkout main


### PR DESCRIPTION
I had never used any of `pypanther` make commands. It seems it required some setup prior to using the different Makefile targets. 

Added a `setup` target that copies the code from the GitHub setup workflow

### Confidence

I hadn't tried any `pypanther` Makefile target before. I tried and it failed since I didn't have poetry installed. 
I added the target. 
Ran `make setup` successfully
Ran `mage test`, `make fmt`, `make lint` successfully
