### PR TITLE
remove expected destinations

### DIFF
--- a/pypanther/base.py
+++ b/pypanther/base.py
@@ -393,8 +393,6 @@ class Rule(metaclass=abc.ABCMeta):
                     test.expected_severity is not None and test.expected_severity != detection_result.severity_output,
                     test.expected_title is not None and test.expected_title != detection_result.title_output,
                     test.expected_dedup is not None and test.expected_dedup != detection_result.dedup_output,
-                    test.expected_destinations is not None
-                    and test.expected_destinations != detection_result.destinations_output,
                     test.expected_runbook is not None and test.expected_runbook != detection_result.runbook_output,
                     test.expected_reference is not None
                     and test.expected_reference != detection_result.reference_output,

--- a/pypanther/testing.py
+++ b/pypanther/testing.py
@@ -101,7 +101,6 @@ def print_failed_test_results(
                 Rule.title.__name__,
                 Rule.description.__name__,
                 Rule.runbook.__name__,
-                Rule.destinations.__name__,
                 Rule.alert_context.__name__,
                 Rule.reference.__name__,
                 Rule.dedup.__name__,

--- a/pypanther/unit_tests.py
+++ b/pypanther/unit_tests.py
@@ -53,11 +53,14 @@ class RuleTest(metaclass=FileLocationMeta):
     expected_severity: Severity | str | None = None
     expected_title: str | None = None
     expected_dedup: str | None = None
-    expected_destinations: list[str] | None = None
     expected_runbook: str | None = None
     expected_reference: str | None = None
     expected_description: str | None = None
     expected_alert_context: dict | None = None
+    # expected_destinations is not included here because the `destinations` function
+    # checks a list of valid destinations to check if the destination exists, and if it is
+    # the name of the destination, it gets the id of it. pypanther does not provide support
+    # for supplying that list to tests yet so this aux check is excluded.
     _file_path: str = ""
     _line_no: int = 0
     _module: str = ""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1397,36 +1397,6 @@ class TestRule(TestCase):
         test = RuleTest(name="test", expected_result=True, log={}, expected_dedup="")
         assert not Test().run_test(test, get_data_model).passed
 
-    def test_expected_destinations(self) -> None:
-        class Test(Rule):
-            id = "TestRule"
-            log_types = [LogType.PANTHER_AUDIT]
-            default_severity = Severity.CRITICAL
-
-            def rule(self, event: PantherEvent) -> bool:
-                return True
-
-            def destinations(self, event) -> list[str]:
-                return ["hi"]
-
-        test = RuleTest(name="test", expected_result=True, log={})
-        assert Test().run_test(test, get_data_model).passed
-
-        test = RuleTest(
-            name="test",
-            expected_result=True,
-            log={},
-            # TODO: you can't supply output names in tests right now so this list will always come back empty
-            expected_destinations=[],
-        )
-        assert Test().run_test(test, get_data_model).passed
-
-        test = RuleTest(name="test", expected_result=True, log={}, expected_destinations=["bad"])
-        assert not Test().run_test(test, get_data_model).passed
-
-        test = RuleTest(name="test", expected_result=True, log={}, expected_destinations=[""])
-        assert not Test().run_test(test, get_data_model).passed
-
     def test_expected_runbook(self) -> None:
         class Test(Rule):
             id = "TestRule"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -155,7 +155,6 @@ class TestPrintFailedTestResults:
             expected_alert_context={"bad": "bad"},
             expected_runbook="bad",
             expected_description="bad",
-            expected_destinations=["bad"],
         )
 
         class Rule1(Rule):
@@ -191,10 +190,6 @@ class TestPrintFailedTestResults:
         )
         assert (
             "Rule1: test 'false test 1' returned the wrong result calling description(), expected bad but got ''"
-            in caplog.text
-        )
-        assert (
-            "Rule1: test 'false test 1' returned the wrong result calling destinations(), expected ['bad'] but got ['SKIP']"
             in caplog.text
         )
         assert (


### PR DESCRIPTION
`expected_destinations` is not included here because the `destinations` function checks a list of valid destinations to check if the destination exists, and if it is the name of the destination, it gets the id of it. `pypanther` does not provide support for supplying that list to tests yet so this aux check is excluded.

Before, if the `destination` func returned anything, the results would instead be replaced with `[]`. If the `destionations` func returned `[]` already, it would get replaced with `["SKIP"]`. 