### PR TITLE
Removing ID from Data Models

### DIFF
--- a/pypanther/data_models_v2.py
+++ b/pypanther/data_models_v2.py
@@ -106,7 +106,6 @@ class DataModel(abc.ABC):
     @classmethod
     def override(
         cls,
-        id: Optional[str] = None,
         description: Optional[str] = None,
         enabled: Optional[bool] = None,
         fields: Optional[List[Field]] = None,

--- a/pypanther/get.py
+++ b/pypanther/get.py
@@ -4,11 +4,11 @@ from types import ModuleType
 from typing import Any, List, Set, Type
 
 from prettytable import PrettyTable
-from pydantic import PositiveInt, NonNegativeInt
+from pydantic import NonNegativeInt, PositiveInt
 
+from pypanther.base import DataModel, Rule
 from pypanther.severity import Severity
 from pypanther.unit_tests import RuleTest
-from pypanther.base import DataModel, Rule
 
 __RULES: Set[Type[Rule]] = set()
 

--- a/tests/test_data_models_v2.py
+++ b/tests/test_data_models_v2.py
@@ -20,11 +20,10 @@ def test_data_model_inheritance():
     )
 
     class Test(DataModel):
-        data_model_id = "test"
         fields = [test_field_1]
 
     class Test2(Test):
-        data_model_id = "test2"
+        pass
 
     # values are inherited as copies
     assert Test2.fields == [test_field_1]
@@ -42,7 +41,6 @@ def test_data_model_inheritance():
 
 def test_override():
     class Test(DataModel):
-        id = "old"
         description = "old description"
         enabled = True
         fields = [
@@ -53,7 +51,6 @@ def test_override():
             )
         ]
 
-    assert Test.id == "old"
     assert Test.description == "old description"
     assert Test.enabled
     assert Test.fields == [
@@ -65,7 +62,6 @@ def test_override():
     ]
 
     Test.override(
-        id="new",
         description="new description",
         enabled=False,
         fields=[
@@ -77,7 +73,6 @@ def test_override():
         ],
     )
 
-    assert Test.id == "new"
     assert Test.description == "new description"
     assert not Test.enabled
     assert Test.fields == [
@@ -91,7 +86,6 @@ def test_override():
 
 def test_asdict():
     class Test(DataModel):
-        id = "old"
         description = "old description"
         enabled = True
         fields = [
@@ -103,7 +97,6 @@ def test_asdict():
         ]
 
     assert Test.asdict() == {
-        "id": "old",
         "description": "old description",
         "enabled": True,
         "fields": [

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,11 +1,11 @@
 import textwrap
 import unittest
+from unittest import TestCase
 
 import pytest
 
 from pypanther.base import Rule
-from pypanther.get import get_rules, print_rule_table, get_panther_rules
-from unittest import TestCase
+from pypanther.get import get_panther_rules, get_rules, print_rule_table
 
 
 class TestGetPantherRules(TestCase):


### PR DESCRIPTION
We have already discussed how we we want RuleID to be optional. The reason we keep the rule_id is mostly backwards compatibility issues with existing rules. 

For Data Models, that are new struct, we don't need to have the id in; we can just rely on the name of the Data Model to be the unique identifier

https://www.notion.so/pantherlabs/Data-Models-v2-MVP-51e01af1342e466fbae93167ed88a85b?pvs=4#a2ebd2c6044e417eba71b2ebf28cb069