### PR TITLE
EPD-722 Filter registered rules in list

### DIFF
--- a/pypanther/list_rules.py
+++ b/pypanther/list_rules.py
@@ -19,7 +19,22 @@ def run(args: argparse.Namespace) -> Tuple[int, str]:
             import_main(os.getcwd(), "main")
         except NoMainModuleError:
             return 1, "No main.py found. Cannot use --registered option without main.py."
-        rules = registered_rules()
+        rules = registered_rules(
+            log_types=args.log_types,
+            id=args.id,
+            create_alert=args.create_alert,
+            dedup_period_minutes=args.dedup_period_minutes,
+            display_name=args.display_name,
+            enabled=args.enabled,
+            summary_attributes=args.summary_attributes,
+            threshold=args.threshold,
+            tags=args.tags,
+            default_severity=args.default_severity,
+            default_description=args.default_description,
+            default_reference=args.default_reference,
+            default_runbook=args.default_runbook,
+            default_destinations=args.default_destinations,
+        )
 
     if args.managed:
         panther_rules = get_panther_rules(


### PR DESCRIPTION
```
pypanther list rules --registered
+----------------------------------------------------------------+-------------------------------------+------------------+---------+
|                               id                               |              log_types              | default_severity | enabled |
+----------------------------------------------------------------+-------------------------------------+------------------+---------+
|      AWS.CloudTrail.AMIModifiedForPublicAccess-prototype       |            AWS.CloudTrail           |      MEDIUM      |   True  |
|           AWS.CloudTrail.Account.Discovery-prototype           |            AWS.CloudTrail           |       LOW        |   True  |
|      AWS.CloudTrail.CodebuildProjectMadePublic-prototype       |            AWS.CloudTrail           |       HIGH       |   True  |
...
|              Okta.User.MFA.Reset.Single-prototype              |            Okta.SystemLog           |       INFO       |   True  |
|        Okta.User.Reported.Suspicious.Activity-prototype        |            Okta.SystemLog           |       HIGH       |   True  |
|               Standard.BruteForceByIP-prototype                |   Asana.Audit, Atlassian.Audit, +6  |       INFO       |   True  |
|           Standard.ImpossibleTravel.Login-prototype            |   Asana.Audit, AWS.CloudTrail, +2   |       HIGH       |   True  |
|                 Standard.MFADisabled-prototype                 |  Atlassian.Audit, GitHub.Audit, +2  |       HIGH       |   True  |
|            Standard.NewAWSAccountCreated-prototype             |            AWS.CloudTrail           |       INFO       |   True  |
|            Standard.NewUserAccountCreated-prototype            | OneLogin.Events, AWS.CloudTrail, +1 |       INFO       |   True  |
+----------------------------------------------------------------+-------------------------------------+------------------+---------+
```
```
pypanther list rules --registered --log-type Asana.Audit
+-------------------------------------------+----------------------------------+------------------+---------+
|                     id                    |            log_types             | default_severity | enabled |
+-------------------------------------------+----------------------------------+------------------+---------+
|     Standard.BruteForceByIP-prototype     | Asana.Audit, Atlassian.Audit, +6 |       INFO       |   True  |
| Standard.ImpossibleTravel.Login-prototype | Asana.Audit, AWS.CloudTrail, +2  |       HIGH       |   True  |
+-------------------------------------------+----------------------------------+------------------+---------+
```