### PR TITLE
add default attributes to help text in list rules

### DIFF
--- a/pypanther/setup_subparsers.py
+++ b/pypanther/setup_subparsers.py
@@ -18,7 +18,7 @@ def setup_list_rules_parser(list_rules_parser: argparse.ArgumentParser):
         "--attributes",
         help="Display attributes of rules as columns in printed table (i.e --attributes threshold default_display_name)",
         nargs="+",
-        default=None,
+        default=display.DEFAULT_RULE_TABLE_ATTRS,
         required=False,
         choices=display.VALID_RULE_TABLE_ATTRS,
     )


### PR DESCRIPTION
Add default attributes to help text in list rules

```
usage: pypanther list rules [-h] [--log-types LOG_TYPES [LOG_TYPES ...]] [--id ID] [--create-alert CREATE_ALERT]
...

options:
  -h, --help            show this help message and exit
...
  --attributes {id,log_types,default_severity,enabled,create_alert,dedup_period_minutes,display_name,summary_attributes,threshold,tags,default_description,default_reference,default_runbook,default_destinations} [{id,log_types,default_severity,enabled,create_alert,dedup_period_minutes,display_name,summary_attributes,threshold,tags,default_description,default_reference,default_runbook,default_destinations} ...]
                        Display attributes of rules as columns in printed table (i.e --attributes threshold default_display_name)
                        (default: ['id', 'log_types', 'default_severity', 'enabled'])
```