### PR TITLE
Limiting upload zip to 4mb

### DIFF
--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -38,6 +38,11 @@ UPLOAD_RESULT_SUCCESS = "UPLOAD_SUCCEEDED"
 UPLOAD_RESULT_FAILURE = "UPLOAD_FAILED"
 UPLOAD_RESULT_TESTS_FAILED = "TESTS_FAILED"
 
+# There are a couple backend limitations that require the size to be this low.
+# The graphql client requires it to be a limit of 4MB. On top of this, there is
+# another backend error that requires it to be even lower. This number was calculated
+# by registering all OOTB rules and then adding in custom rules after it.
+# To be fixed here: https://panther-labs.atlassian.net/browse/EPD-903
 UPLOAD_SIZE_LIMIT_MB = 1.5
 UPLOAD_SIZE_LIMIT_BYTES = UPLOAD_SIZE_LIMIT_MB * 1024 * 1024
 


### PR DESCRIPTION
We seemed to be hitting a graphql size limit on upload saying our payload is too big. 

I added a limit of 1.5mb to the zipped contents.

 I don't know what the real limit is, but 5mb still got the error and 4mb didn't. On top of this, I reduced it more to help avoid another BE error we can get. 
```
Upload Failed
   - Response payload size exceeded maximum allowed payload size (6291556 bytes).
```

This size is checked before the base64 encoding.

If the size is too big, it prints an error like the following
```
[ERROR][root]: Zip file is too big. Reduce number of files or contents of files before uploading again (Limit: 4 MB, Zip size: 4.014 MB).
```