### PR TITLE
ignore venv folder on upload

### DIFF
--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -32,6 +32,7 @@ IGNORE_FOLDERS = [
     ".git",
     "__pycache__",
     "tests",
+    ".venv",
 ]
 
 UPLOAD_RESULT_SUCCESS = "UPLOAD_SUCCEEDED"


### PR DESCRIPTION
The `.venv` directory is created when using the `venv` virtual environment manager. It contains lots of `.py` files that should not be uploaded. 