### PR TITLE
Fix generate Script Bug

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -216,7 +216,7 @@ def run_ruff(paths: List[Path]):
         "TD001",
     ]
     subprocess.run(["ruff", "check", "--fix", "--ignore", ",".join(ignored_checks)] + list(paths), check=True)
-    subprocess.run(["ruff", "format"] + list(paths), check=True)
+    subprocess.run(["ruff", "format", "--silent"] + list(paths), check=True)
 
 
 def to_ascii(s):


### PR DESCRIPTION
Fixed a bug where `to_snake_case` was erroneously used in place of `convert_rule_attribute_name`.

Test:

Setup:
```shell
❯ git clone --branch main https://github.com/panther-labs/panther-analysis.git
Cloning into 'panther-analysis'...
remote: Enumerating objects: 16295, done.
remote: Counting objects: 100% (2664/2664), done.
remote: Compressing objects: 100% (335/335), done.
remote: Total 16295 (delta 2431), reused 2331 (delta 2329), pack-reused 13631 (from 1)
Receiving objects: 100% (16295/16295), 5.74 MiB | 403.00 KiB/s, done.
Resolving deltas: 100% (12442/12442), done.
/tmp took 15s 
❯ sed -i '' -e 's/Description:.*$/Description: CHANGED DESCRIPTION/' ./panther-analysis/rules/github_rules/github_webhook_modified.yml
```

Before the fix:
```shell
❯ python generate.py ./panther-analysis        
Error processing /tmp/panther-analysis/rules/github_rules/github_repo_archived.yml: Detection not implemented
Error processing /tmp/panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml: AnalysisType must be 'rule', not correlation_rule
Error processing /tmp/panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml: AnalysisType must be 'rule', not correlation_rule
Created __init__.py in pypanther/rules
Created __init__.py in pypanther/rules/tines
Created __init__.py in pypanther/rules/osquery
Created __init__.py in pypanther/rules/sentinelone
Created __init__.py in pypanther/rules/box
Created __init__.py in pypanther/rules/crowdstrike
Created __init__.py in pypanther/rules/crowdstrike/event_stream
Created __init__.py in pypanther/rules/aws_vpc_flow
Created __init__.py in pypanther/rules/gitlab
Created __init__.py in pypanther/rules/gcp_audit
Created __init__.py in pypanther/rules/cisco_umbrella_dns
Created __init__.py in pypanther/rules/aws_securityfinding
Created __init__.py in pypanther/rules/push_security
Created __init__.py in pypanther/rules/aws_eks
Created __init__.py in pypanther/rules/zoom_operation
Created __init__.py in pypanther/rules/wiz
Created __init__.py in pypanther/rules/microsoft
Created __init__.py in pypanther/rules/indicator_creation
Created __init__.py in pypanther/rules/onepassword
Created __init__.py in pypanther/rules/cloudflare
Created __init__.py in pypanther/rules/azure_signin
Created __init__.py in pypanther/rules/gcp_http_lb
Created __init__.py in pypanther/rules/carbonblack
Created __init__.py in pypanther/rules/onelogin
Created __init__.py in pypanther/rules/mongodb
Created __init__.py in pypanther/rules/standard
Created __init__.py in pypanther/rules/notion
Created __init__.py in pypanther/rules/appomni
Created __init__.py in pypanther/rules/snyk
Created __init__.py in pypanther/rules/gcp_k8s
Created __init__.py in pypanther/rules/gsuite_reports
Created __init__.py in pypanther/rules/github
Created __init__.py in pypanther/rules/atlassian
Created __init__.py in pypanther/rules/zendesk
Created __init__.py in pypanther/rules/aws_guardduty
Created __init__.py in pypanther/rules/okta
Created __init__.py in pypanther/rules/tailscale
Created __init__.py in pypanther/rules/dropbox
Created __init__.py in pypanther/rules/salesforce
Created __init__.py in pypanther/rules/slack
Created __init__.py in pypanther/rules/gsuite_activityevent
Created __init__.py in pypanther/rules/aws_s3
Created __init__.py in pypanther/rules/gravitational_teleport
Created __init__.py in pypanther/rules/panther_audit
Created __init__.py in pypanther/rules/auth0
Created __init__.py in pypanther/rules/aws_cloudtrail
Created __init__.py in pypanther/rules/asana
Created __init__.py in pypanther/rules/duo
Created __init__.py in pypanther/rules/sublime
Created __init__.py in pypanther/rules/netskope
Traceback (most recent call last):
  File "/Users/nikos/Workspace/Panther/pypanther/main/kakouxia/../generate.py", line 1287, in <module>
    main()
  File "/Users/nikos/Workspace/Panther/pypanther/main/kakouxia/../generate.py", line 1279, in main
    refactor_yaml_only_modified_rules(rules_path, overrides_path, yaml_diff)
  File "/Users/nikos/Workspace/Panther/pypanther/main/kakouxia/../generate.py", line 1121, in refactor_yaml_only_modified_rules
    value = [
            ^
IndexError: list index out of range
```

After:
```shell
❯ python generate.py ./panther-analysis 
Error processing /tmp/panther-analysis/rules/github_rules/github_repo_archived.yml: Detection not implemented
Error processing /tmp/panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml: AnalysisType must be 'rule', not correlation_rule
Error processing /tmp/panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml: AnalysisType must be 'rule', not correlation_rule
Created __init__.py in pypanther/rules
Created __init__.py in pypanther/rules/tines
Created __init__.py in pypanther/rules/osquery
Created __init__.py in pypanther/rules/sentinelone
Created __init__.py in pypanther/rules/box
Created __init__.py in pypanther/rules/crowdstrike
Created __init__.py in pypanther/rules/crowdstrike/event_stream
Created __init__.py in pypanther/rules/aws_vpc_flow
Created __init__.py in pypanther/rules/gitlab
Created __init__.py in pypanther/rules/gcp_audit
Created __init__.py in pypanther/rules/cisco_umbrella_dns
Created __init__.py in pypanther/rules/aws_securityfinding
Created __init__.py in pypanther/rules/push_security
Created __init__.py in pypanther/rules/aws_eks
Created __init__.py in pypanther/rules/zoom_operation
Created __init__.py in pypanther/rules/wiz
Created __init__.py in pypanther/rules/microsoft
Created __init__.py in pypanther/rules/indicator_creation
Created __init__.py in pypanther/rules/onepassword
Created __init__.py in pypanther/rules/cloudflare
Created __init__.py in pypanther/rules/azure_signin
Created __init__.py in pypanther/rules/gcp_http_lb
Created __init__.py in pypanther/rules/carbonblack
Created __init__.py in pypanther/rules/onelogin
Created __init__.py in pypanther/rules/mongodb
Created __init__.py in pypanther/rules/standard
Created __init__.py in pypanther/rules/notion
Created __init__.py in pypanther/rules/appomni
Created __init__.py in pypanther/rules/snyk
Created __init__.py in pypanther/rules/gcp_k8s
Created __init__.py in pypanther/rules/gsuite_reports
Created __init__.py in pypanther/rules/github
Created __init__.py in pypanther/rules/atlassian
Created __init__.py in pypanther/rules/zendesk
Created __init__.py in pypanther/rules/aws_guardduty
Created __init__.py in pypanther/rules/okta
Created __init__.py in pypanther/rules/tailscale
Created __init__.py in pypanther/rules/dropbox
Created __init__.py in pypanther/rules/salesforce
Created __init__.py in pypanther/rules/slack
Created __init__.py in pypanther/rules/gsuite_activityevent
Created __init__.py in pypanther/rules/aws_s3
Created __init__.py in pypanther/rules/gravitational_teleport
Created __init__.py in pypanther/rules/panther_audit
Created __init__.py in pypanther/rules/auth0
Created __init__.py in pypanther/rules/aws_cloudtrail
Created __init__.py in pypanther/rules/asana
Created __init__.py in pypanther/rules/duo
Created __init__.py in pypanther/rules/sublime
Created __init__.py in pypanther/rules/netskope
Found 455 errors (455 fixed, 0 remaining).
warning: The following rules may cause conflicts when used with the formatter: `COM812`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
60 files reformatted, 4 files left unchanged
```