### PR TITLE
Improve Dry Run

### DIFF
--- a/pypanther/backend/client.py
+++ b/pypanther/backend/client.py
@@ -120,6 +120,7 @@ class BulkUploadStatistics:
     new_ids: list[str] | None
     total_ids: list[str] | None
     deleted_ids: list[str] | None
+    modified_ids: list[str] | None
 
 
 @dataclass(frozen=True)
@@ -622,6 +623,7 @@ def to_bulk_upload_statistics(data: Any) -> BackendResponse[AsyncBulkUploadStatu
                 new_ids=rules.get("newIds", None),
                 total_ids=rules.get("totalIds", None),
                 deleted_ids=rules.get("deletedIds", None),
+                modified_ids=rules.get("modifiedIds", None),
             ),
         ),
     )
@@ -640,6 +642,7 @@ def to_bulk_upload_response(data: Any) -> BackendResponse[BulkUploadResponse]:
                 new_ids=rules.get("newIds", None),
                 total_ids=rules.get("totalIds", None),
                 deleted_ids=rules.get("deletedIds", None),
+                modified_ids=rules.get("modifiedIds", None),
             ),
         ),
     )

--- a/pypanther/backend/graphql/async_bulk_upload_status.graphql
+++ b/pypanther/backend/graphql/async_bulk_upload_status.graphql
@@ -36,4 +36,5 @@ fragment UploadStatisticDetails on UploadStatistics {
     newIds
     totalIds
     deletedIds
+    modifiedIds
 }

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -50,9 +50,11 @@ class ChangesSummary(TypedDict):
     message: str
     new: int
     delete: int
+    modify: int
     total: int
     new_ids: list[str] | None
     delete_ids: list[str] | None
+    modify_ids: list[str] | None
     total_ids: list[str] | None
 
 
@@ -196,9 +198,11 @@ def dry_run_upload(backend: BackendClient, data: bytes, verbose, output_type) ->
         message=f"Will add {upload_stats.rules.new} new rules and delete {upload_stats.rules.deleted} rules (total {upload_stats.rules.total} rules)",
         new=upload_stats.rules.new,
         delete=upload_stats.rules.deleted,
+        modify=upload_stats.rules.modified,
         total=upload_stats.rules.total,
         new_ids=upload_stats.rules.new_ids,
         delete_ids=upload_stats.rules.deleted_ids,
+        modify_ids=upload_stats.rules.modified_ids,
         total_ids=upload_stats.rules.total_ids,
     )
     return changes_summary
@@ -337,7 +341,7 @@ def get_upload_output_as_dict(
             "message": changes_summary["message"],
             "new": changes_summary["new"],
             "delete": changes_summary["delete"],
-            "total": changes_summary["total"],
+            "modify": changes_summary["modify"],
         }
 
     return output
@@ -406,14 +410,19 @@ def print_changes_summary(changes_summary: ChangesSummary) -> None:
         print(f"New [{changes_summary['new']}]:")
         for id_ in changes_summary["new_ids"]:
             print(f"+ {id_}")
-    print()  # new line
+        print()  # new line
     if changes_summary["delete_ids"]:
         print(f"Delete [{changes_summary['delete']}]:")
         for id_ in changes_summary["delete_ids"]:
             print(f"- {id_}")
-    print()  # new line
+        print()  # new line
+    if changes_summary["modify_ids"]:
+        print(f"Modify [{changes_summary['modify']}]:")
+        for id_ in changes_summary["modify_ids"]:
+            print(f"~ {id_}")
+        print()  # new line
     print(cli_output.header("Changes Summary"))
     print(INDENT, f"New:     {changes_summary['new']:>3}")
     print(INDENT, f"Delete:  {changes_summary['delete']:>3}")
-    print(INDENT, f"Total:   {changes_summary['total']:>3}")
+    print(INDENT, f"Modify:  {changes_summary['modify']:>3}")
     print()  # new line


### PR DESCRIPTION
Improving dry run:
- removed "total" section from the changes summary (based on previous feedback)
- added "modified" section in the changes summary
- print modified ids

Testing:
```shell
❯ pypanther upload --dry-run
WARNING: pypanther upload is under active development and not recommended for use without guidance from the Panther team. Would you like to proceed? [y/n]: y

Test Summary:
   Skipped rules: 499 (499 panther managed)
   Passed rules:    0 
   Failed rules:    0 
   Total rules:   499

   Passed tests:    0
   Failed tests:    0
   Total tests:     0

Calculating changes

Will add 0 new rules and delete 1 rules (total 479 rules)

Delete [1]:
- Box.Shield.Anomalous.Download.Custom

Modify [1]:
~ MyOtherRule

Changes Summary
   New:       0
   Delete:    1
   Modify:    1

❯ pypanther upload          
WARNING: pypanther upload is under active development and not recommended for use without guidance from the Panther team. Would you like to proceed? [y/n]: y

Test Summary:
   Skipped rules: 499 (499 panther managed)
   Passed rules:    0 
   Failed rules:    0 
   Total rules:   499

   Passed tests:    0
   Failed tests:    0
   Total tests:     0

Calculating changes

Will add 0 new rules and delete 1 rules (total 479 rules)

Delete [1]:
- Box.Shield.Anomalous.Download.Custom

Modify [1]:
~ MyOtherRule

Changes Summary
   New:       0
   Delete:    1
   Modify:    1

Would you like to make this change? [y/n]: y

Uploading to Panther

Upload Statistics
   Rules:
     New:       0
     Modified:  1
     Deleted:   1
     Total:     479

Upload succeeded
```