### PR TITLE
Specify Directory for ruff in generate Script

### DIFF
--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -1484,7 +1484,8 @@ def convert(args: argparse.Namespace) -> tuple[int, str]:
             delete_helpers(Path("./pypanther/helpers/"), helpers_to_delete)
             delete_data_models(Path("./pypanther/data_models/"))
 
-        run_ruff([Path(".")])  # noqa: PTH201
+        # "pypanther" is the default output directory; we only to run ruff on those
+        run_ruff([Path("./pypanther/")])
     except Exception as exc:
         if hasattr(args, "verbose") and args.verbose:
             print(exc)


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

<!-- more "the why" than "the what" -->

Sync PA GitHub Action fails like [this](https://github.com/panther-labs/pypanther/actions/runs/11351223972/job/31571333891#step:8:15).

The reason is that in the generate script we run ruff for the current directory recursively. The Sync PA GitHub Action puts more stuff in the current directory, ruff runs on these as well and produces errors that are irrelevant for this scope.

### References: <!-- related links -->

<!-- relates to: JIRA Ticket # automation will link this PR to the JIRA -->
<!-- closes: JIRA Ticket # automation will link this PR to JIRA and close it -->

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

<!-- were relevant tests performed? Unit tests, E2E tests, etc
     Include steps you followed to test the changes as well as output of the tests
-->
<!-- reviewers should be able to understand how it was tested and have confidence in the change -->

I kinda replicated the way this github action runs:
```shell
/tmp 
❯ git clone --branch main git@github.com:panther-labs/pypanther.git
Cloning into 'pypanther'...
Enter passphrase for key '/Users/nikos/.ssh/id_ecdsa_sk': 
Confirm user presence for key ECDSA-SK SHA256:eebyBnpnRKW2wf/4UvUgrXfxumRXdqd8jtWkRwdh2ec
User presence confirmed
remote: Enumerating objects: 17712, done.
remote: Counting objects: 100% (6258/6258), done.
remote: Compressing objects: 100% (2086/2086), done.
remote: Total 17712 (delta 5124), reused 4660 (delta 4170), pack-reused 11454 (from 1)
Receiving objects: 100% (17712/17712), 5.02 MiB | 2.79 MiB/s, done.
Resolving deltas: 100% (15546/15546), done.
/tmp took 7s 
❯ cd pypanther 
pypanther on  main via 🐍 v3.9.6 
❯ git clone --branch main git@github.com:panther-labs/panther-analysis.git
Cloning into 'panther-analysis'...
Enter passphrase for key '/Users/nikos/.ssh/id_ecdsa_sk': 
Confirm user presence for key ECDSA-SK SHA256:eebyBnpnRKW2wf/4UvUgrXfxumRXdqd8jtWkRwdh2ec
User presence confirmed
remote: Enumerating objects: 16804, done.
remote: Counting objects: 100% (2955/2955), done.
remote: Compressing objects: 100% (478/478), done.
remote: Total 16804 (delta 2624), reused 2510 (delta 2477), pack-reused 13849 (from 1)
Receiving objects: 100% (16804/16804), 5.87 MiB | 1.45 MiB/s, done.
Resolving deltas: 100% (12817/12817), done.
pypanther on  main [?] via 🐍 v3.9.6 took 11s 
❯ poetry install
The currently activated Python version 3.12.7 is not supported by the project (3.11.*).
Trying to find and use a compatible version. 
Using python3.11 (3.11.10)
Creating virtualenv pypanther-3s8JgBt1-py3.11 in /Users/nikos/Library/Caches/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 61 installs, 0 updates, 0 removals

  - Installing six (1.16.0)
  - Installing certifi (2024.8.30)
  - Installing charset-normalizer (3.3.2)
  - Installing idna (3.8)
  - Installing jmespath (1.0.1)
  - Installing python-dateutil (2.9.0.post0)
  - Installing urllib3 (2.2.2)
  - Installing botocore (1.35.16)
  - Installing distlib (0.3.8)
  - Installing filelock (3.16.0)
  - Installing frozenlist (1.4.1)
  - Installing multidict (6.1.0)
  - Installing platformdirs (4.3.2)
  - Installing ply (3.11)
  - Installing requests (2.32.3)
  - Installing smmap (5.0.1)
  - Installing sniffio (1.3.1)
  - Installing typing-extensions (4.12.2)
  - Installing aiohappyeyeballs (2.4.0)
  - Installing aiosignal (1.3.1)
  - Installing annotated-types (0.7.0)
  - Installing anyio (4.4.0)
  - Installing attrs (24.2.0)
  - Installing backoff (2.2.1)
  - Installing cfgv (3.4.0)
  - Installing datadog (0.50.0)
  - Installing gitdb (4.0.11)
  - Installing graphql-core (3.2.4)
  - Installing identify (2.6.0)
  - Installing iniconfig (2.0.0)
  - Installing jsonpath-ng (1.6.1)
  - Installing mypy-extensions (1.0.0)
  - Installing nodeenv (1.9.1)
  - Installing packaging (24.1)
  - Installing pluggy (1.5.0)
  - Installing pyyaml (6.0.2)
  - Installing ruamel-yaml-clib (0.2.8)
  - Installing pydantic-core (2.23.3)
  - Installing s3transfer (0.10.2)
  - Installing virtualenv (20.26.4)
  - Installing wcwidth (0.2.13)
  - Installing yarl (1.11.1)
  - Installing aiohttp (3.10.1)
  - Installing ast-comments (1.2.2)
  - Installing boto3 (1.35.16)
  - Installing colorama (0.4.6)
  - Installing dynaconf (3.2.6)
  - Installing gitpython (3.1.43)
  - Installing gql (3.5.0)
  - Installing mypy (1.10.1)
  - Installing panther-core (0.11.2)
  - Installing panther-detection-helpers (0.4.0)
  - Installing policyuniverse (1.5.1.20231109)
  - Installing pre-commit (3.8.0)
  - Installing prettytable (3.11.0)
  - Installing pydantic (2.9.1)
  - Installing pytest (8.3.3)
  - Installing ruamel-yaml (0.18.6)
  - Installing ruff (0.4.10)
  - Installing types-python-dateutil (2.9.0.20240906)
  - Installing types-pyyaml (6.0.12.20240808)

Installing the current project: pypanther (0.1.1a49)
pypanther on  main [?] via 🐍 v3.9.6 took 3s 
❯ poetry run python ./pypanther/generate.py panther-analysis --keep-all-rules
The currently activated Python version 3.12.7 is not supported by the project (3.11.*).
Trying to find and use a compatible version. 
Using python3.11 (3.11.10)
Error processing panther-analysis/rules/github_rules/github_repo_archived.yml: Detection not implemented
Error processing panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml: AnalysisType must be 'rule', not correlation_rule
Error processing panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml: AnalysisType must be 'rule', not correlation_rule
Found 87321 errors (87321 fixed, 0 remaining).
```

Before the fix, the output of the last command looked like this:
```shell
pypanther on  main [?] via 🐍 v3.9.6 took 3s 
❯ poetry run python ./pypanther/generate.py panther-analysis --keep-all-rules
The currently activated Python version 3.12.7 is not supported by the project (3.11.*).
Trying to find and use a compatible version. 
Using python3.11 (3.11.10)
Error processing panther-analysis/rules/github_rules/github_repo_archived.yml: Detection not implemented
Error processing panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_new_admin_user_created.yml: AnalysisType must be 'rule', not correlation_rule
Error processing panther-analysis/rules/crowdstrike_rules/event_stream_rules/crowdstrike_ephemeral_user_account.yml: AnalysisType must be 'rule', not correlation_rule
panther-analysis/.scripts/deleted_rules.py:20:29: S607 Starting a process with a partial executable path
Found 87881 errors (87880 fixed, 1 remaining).
conversion failed
```

<!-- pr guide: https://www.notion.so/pantherlabs/Github-Pull-Requests-PR-02af4e80f53844f985889d5c36874c6d#6a36878f77fb43a0b3539d93ee3c3da1 -->
<!-- reviewing guide: https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6 -->
