### PR TITLE
Refactor to print even on dry-run

### DIFF
--- a/pypanther/main.py
+++ b/pypanther/main.py
@@ -6,7 +6,6 @@ from typing import Callable, Tuple
 
 from gql.transport.exceptions import TransportServerError, TransportQueryError
 
-import pypanther.backend.errors
 from pypanther import testing, cli_output
 from pypanther.custom_logging import setup_logging
 from pypanther.setup_subparsers import (

--- a/pypanther/schemas.py
+++ b/pypanther/schemas.py
@@ -58,7 +58,7 @@ def prepare(backend: BackendClient, args: argparse.Namespace) -> Tuple[list[Uplo
     schemas = uploader.prepare()
 
     # we need to print errors from local files from this early on
-    report_summary(absolute_path, schemas, args.dry_run, args.verbose)
+    report_summary(absolute_path, schemas, args.verbose)
 
     return schemas, absolute_path
 
@@ -67,7 +67,6 @@ def apply(
     backend: BackendClient,
     schemas: list[UploaderResult],
     path: str,
-    dry_run: bool,
     verbose: bool,
 ) -> Tuple[list[UploaderResult], bool]:
     errored = False
@@ -81,7 +80,7 @@ def apply(
             errored = True
             s.error = f"failure to update schema {s.name}: " f"message={exc}"
 
-    report_summary(path, schemas, dry_run, verbose)
+    report_summary(path, schemas, verbose)
     return schemas, errored
 
 
@@ -389,17 +388,13 @@ def normalize_path(path: str) -> Optional[str]:
     return str(absolute_path)
 
 
-def report_summary(base_path: str, results: List[UploaderResult], dry_run: bool, verbose: bool):
+def report_summary(base_path: str, results: List[UploaderResult], verbose: bool):
     """
     Translate uploader results to descriptive status messages and prints them.
-    Prints only on verbose, dry-runs and on errors.
+    Prints only on verbose and on errors.
     """
     for result in sorted(results, key=lambda r: r.filename):
         filename = result.filename.split(base_path)[-1].strip(os.path.sep)
-        if dry_run:
-            print(cli_output.cyan(f"DRY-RUN: Would have updated schema from definition in file '{filename}'"))
-            continue
-
         if result.error:
             print(
                 cli_output.failed(

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -395,6 +395,9 @@ def get_upload_output_as_dict(
             "new_rule_ids": len(changes_summary["new_rule_ids"]),
             "delete_rule_ids": len(changes_summary["delete_rule_ids"]),
             "modify_rule_ids": len(changes_summary["modify_rule_ids"]),
+            "new_schema_names": len(changes_summary["new_schema_names"]),
+            "modified_schema_names": len(changes_summary["modified_schema_names"]),
+            "existed_schema_names": len(changes_summary["existed_schema_names"]),
         }
 
     return output
@@ -477,13 +480,13 @@ def print_changes_summary(changes_summary: ChangesSummary) -> None:
         print()  # new line
     if changes_summary["new_schema_names"]:
         print(f"New [{len(changes_summary['new_schema_names'])}]:")
-        for id_ in changes_summary["new_schema_names"]:
-            print(f"+ {id_}")
+        for name in changes_summary["new_schema_names"]:
+            print(f"+ {name}")
         print()  # new line
     if changes_summary["modified_schema_names"]:
         print(f"Modify [{len(changes_summary['modified_schema_names'])}]:")
-        for id_ in changes_summary["modified_schema_names"]:
-            print(f"~ {id_}")
+        for name in changes_summary["modified_schema_names"]:
+            print(f"~ {name}")
     print(cli_output.header("Changes Summary"))
     print(INDENT, f"New Rules:      {len(changes_summary['new_rule_ids']):>4}")
     print(INDENT, f"Modified Rules: {len(changes_summary['modify_rule_ids']):>4}")

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -191,7 +191,7 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:  #
                     return 0, ""
 
         # actually upload schemas
-        _, errored = schemas.apply(backend, schemas_to_upload, schemas_path, args.dry_run, args.verbose)
+        _, errored = schemas.apply(backend, schemas_to_upload, schemas_path, args.verbose)
         if errored:
             return 1, ""
 
@@ -475,7 +475,6 @@ def print_changes_summary(changes_summary: ChangesSummary) -> None:
         for id_ in changes_summary["modify_rule_ids"]:
             print(f"~ {id_}")
         print()  # new line
-    print()  # new line
     if changes_summary["new_schema_names"]:
         print(f"New [{len(changes_summary['new_schema_names'])}]:")
         for id_ in changes_summary["new_schema_names"]:

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -10,7 +10,7 @@ import zipfile
 from dataclasses import asdict
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Optional, Tuple, TypedDict, cast
+from typing import Any, Optional, Tuple, TypedDict
 
 import requests
 
@@ -144,13 +144,14 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:  #
     for res in schemas_to_upload:
         if res.error:  # stop if there's a single error. It's already been printed
             return 1, ""
+        if not res.name:
+            raise ValueError("Schema name is required")
         if res.modified:
-            changes_summary["modified_schema_names"].append(cast(str, res.name))
-            # Note that cast here does nothing at runtime ^
+            changes_summary["modified_schema_names"].append(res.name)
         elif res.existed:
-            changes_summary["existed_schema_names"].append(cast(str, res.name))
+            changes_summary["existed_schema_names"].append(res.name)
         else:
-            changes_summary["new_schema_names"].append(cast(str, res.name))
+            changes_summary["new_schema_names"].append(res.name)
 
     try:
         if not args.confirm:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -35,7 +35,6 @@ class TestUtilities(unittest.TestCase):
                         name=None,
                     ),
                 ],
-                False,
                 True,
             )
             output = buf.getvalue()
@@ -296,7 +295,7 @@ class TestUploader(unittest.TestCase):
             ],
         )
 
-        _, errored = schemas.apply(backend, unfinished_results, self.valid_schema_path, False, False)
+        _, errored = schemas.apply(backend, unfinished_results, self.valid_schema_path, False)
         self.assertFalse(errored)
 
         my_mock_call = backend.update_schema.call_count

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -242,7 +242,25 @@ class TestUploader(unittest.TestCase):
             ],
         )
 
-    def test_process(self):
+    def test_prepare(self):
+        backend = MockBackend()
+        backend.list_schemas = mock.MagicMock(return_value=self.list_schemas_response)
+
+        uploader = schemas.Uploader(self.valid_schema_path, backend)
+        results = uploader.prepare()
+
+        self.assertEqual(len(results), 4)
+        self.assertListEqual(
+            [r.name for r in results],
+            [
+                "Custom.AWSAccountIDs",
+                "Custom.SampleSchema1",
+                "Custom.SampleSchema2",
+                "Custom.Sample.Schema3",
+            ],
+        )
+
+    def test_apply(self):
         backend = MockBackend()
         backend.list_schemas = mock.MagicMock(return_value=self.list_schemas_response)
 
@@ -266,10 +284,10 @@ class TestUploader(unittest.TestCase):
 
         backend.update_schema = mock.MagicMock(side_effect=put_schema_responses)
         uploader = schemas.Uploader(self.valid_schema_path, backend)
-        results = uploader.process()
-        self.assertEqual(len(results), 4)
+        unfinished_results = uploader.prepare()
+        self.assertEqual(len(unfinished_results), 4)
         self.assertListEqual(
-            [r.name for r in results],
+            [r.name for r in unfinished_results],
             [
                 "Custom.AWSAccountIDs",
                 "Custom.SampleSchema1",
@@ -278,10 +296,13 @@ class TestUploader(unittest.TestCase):
             ],
         )
 
+        _, errored = schemas.apply(backend, unfinished_results, self.valid_schema_path, False, False)
+        self.assertFalse(errored)
+
         my_mock_call = backend.update_schema.call_count
         self.assertEqual(my_mock_call, 4)
 
-        self.assertListEqual([r.existed for r in results], [True, True, True, True])
+        self.assertListEqual([r.existed for r in unfinished_results], [True, True, True, True])
         self.assertEqual(backend.update_schema.call_count, 4)
         backend.update_schema.assert_has_calls(
             [


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

* fixes a bug with confirm and schemas (they would have been uploaded even with no confirm)
* report changes for schemas too

### References: <!-- related links -->

Relates to schemas

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

* unit tests
* tested: `pypanther` **(with and without changes)**
* tested: `pypanther --confirm` **(with and without changes)**
* tested: `pypanther --confirm --out json` **(with and without changes)**
* tested: `pypanther --dry-run` **(with and without changes)**
* tested: `pypanther --dry-run --out-json` **(with and without changes)**

### Dry-Run:

![image](https://github.com/user-attachments/assets/541ca9a2-ab8f-43fc-9cd5-f75873dd9e27)

### Example of json output and how `n` stops if no `--confirm` is there:
![image](https://github.com/user-attachments/assets/5c88f654-c216-41e5-88a5-4550f979f490)

### ...and if `y` is given we get these (also schema names on the statistics)
![image](https://github.com/user-attachments/assets/154dc895-695f-4d16-8f3d-ddd52b75d029)
