### PR TITLE
Fix some bugs on schemas upload

### DIFF
--- a/pypanther/rules/crowdstrike/crowdstrike_detection_passthrough.py
+++ b/pypanther/rules/crowdstrike/crowdstrike_detection_passthrough.py
@@ -12,7 +12,7 @@ class CrowdstrikeDetectionpassthrough(Rule):
     default_description = "Crowdstrike Falcon has detected malicious activity on a host."
     default_runbook = "Follow the Falcon console link and follow the IR process as needed."
     default_reference = "https://www.crowdstrike.com/blog/tech-center/hunt-threat-activity-falcon-endpoint-protection/"
-    dedup_period_minutes = 0
+    dedup_period_minutes = 60
     summary_attributes = ["p_any_ip_addresses"]
 
     def rule(self, event):

--- a/pypanther/schemas.py
+++ b/pypanther/schemas.py
@@ -106,7 +106,7 @@ class Manager:
         """
         Check the schemas with the backend. This is in order to report changes during dry-runs and whatnot
         """
-        for schema_mod in self._schemas_to_write:
+        for schema_mod in self.schemas:
             schema = schema_mod.schema
 
             existing_schema = self.find_schema(schema.name)
@@ -145,7 +145,8 @@ class Manager:
                 errored = True
                 s.error = f"failure to update schema {s.name}: " f"message={exc}"
 
-        report_summary(self._path, self.schemas, verbose)
+        if len(self.schemas) > 0:
+            report_summary(self._path, self.schemas, verbose)
         return errored
 
     def do_request(self, s: Schema) -> BackendResponse:

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -448,10 +448,11 @@ def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_re
     print(INDENT * 2, "{:<9} {:>4}".format("Deleted:  ", len(rule_results.deleted_rule_ids)))
     print(INDENT * 2, "{:<9} {:>4}".format("Total:    ", len(rule_results.total_rule_ids)))
     print()  # new line
-    if len(schema_results["new_schema_names"]) > 0 or \
-        len(schema_results["modified_schema_names"]) > 0 or \
-        len(schema_results["existed_schema_names"]) > 0:
-
+    if (
+        len(schema_results["new_schema_names"]) > 0
+        or len(schema_results["modified_schema_names"]) > 0
+        or len(schema_results["existed_schema_names"]) > 0
+    ):
         print(INDENT, cli_output.bold("Schemas:"))
         print(INDENT * 2, "{:<9} {:>4}".format("New:          ", len(schema_results["new_schema_names"])))
         print(INDENT * 2, "{:<9} {:>4}".format("Modified:     ", len(schema_results["modified_schema_names"])))
@@ -498,10 +499,11 @@ def print_changes_summary(changes_summary: ChangesSummary) -> None:
     print(INDENT, f"Deleted Rules:  {len(changes_summary['delete_rule_ids']):>4}")
     print(INDENT, f"Total Rules:    {len(changes_summary['total_rule_ids']):>4}")
     print()  # new line
-    if len(changes_summary["new_schema_names"]) > 0 or \
-        len(changes_summary["modified_schema_names"]) > 0 or \
-        len(changes_summary["existed_schema_names"]) > 0:
-
+    if (
+        len(changes_summary["new_schema_names"]) > 0
+        or len(changes_summary["modified_schema_names"]) > 0
+        or len(changes_summary["existed_schema_names"]) > 0
+    ):
         print(INDENT, f"New Schemas:          {len(changes_summary['new_schema_names']):>4}")
         print(INDENT, f"Modified Schemas:     {len(changes_summary['modified_schema_names']):>4}")
         print(INDENT, f"Not Modified Schemas: {len(changes_summary['existed_schema_names']):>4}")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -255,6 +255,12 @@ class TestUploader(unittest.TestCase):
             ],
         )
 
+    def test_not_existing(self):
+        manager = schemas.Manager("non_existing_schema_path", verbose=False, dry_run=False)
+        # we test that this doesn't go boom
+        manager.check_upstream()
+        manager.apply(False)
+
     def test_apply(self):
         backend = MockBackend()
         backend.list_schemas = mock.MagicMock(return_value=self.list_schemas_response)


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

There are some bugs on the pypanther schemas thingy:
* When there is no `content/schemas` it fails. It shouldn't and it should just continue on the rules.
* `dry-run` practically didn't work because I had put it by mistake inside another if clause

### References: <!-- related links -->

Closes [EPD-2243](https://panther-labs.atlassian.net/browse/EPD-2243)

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

* Ran the command with **and without content/schema** folder with:
  * --confirm
  * --skip-summary  
  * --dry-run
  * --confirm --skip-summary 
  * --confirm --dry-run

This can't go together:
  * --dry-run --skip-summary 

[EPD-2243]: https://panther-labs.atlassian.net/browse/EPD-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ