### PR TITLE
Fix Path Renaming in generate.py

### DIFF
--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -892,7 +892,7 @@ def _convert_rules(p: Path, panther_analysis: Path, helpers: Set[str]):
         return
 
     # strip panther_analysis from path
-    p_str = str(p.relative_to(panther_analysis)).replace("_rules", "")
+    p_str = str(p.relative_to(panther_analysis)).replace("_rules/", "/")
     p = Path("pypanther") / Path(p_str)
 
     p.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

<!-- more "the why" than "the what" -->

`generate.py` wants to rename rules subdirectories from e.g. `rules/sublime_rules/` to `rules/sublime/`.

However, the way it does that currently results in things like `rules/sublime_rules/sublime_rules_deleted_or_deactivated.py` -> `rules/sublime_rules/sublime_deleted_or_deactivated.py` (notice that `_rules` is missing from the file name as well).

### References: <!-- related links -->

<!-- relates to: JIRA Ticket # automation will link this PR to the JIRA -->
<!-- closes: JIRA Ticket # automation will link this PR to JIRA and close it -->

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

<!-- were relevant tests performed? Unit tests, E2E tests, etc
     Include steps you followed to test the changes as well as output of the tests
-->
<!-- reviewers should be able to understand how it was tested and have confidence in the change -->

- cloned panther-analysis main branch locally
- (didn't modify anything)
- before the fix, I converted the rules from panther-analysis to pypanther via `python pypanther/generate.py --verbose --keep-all-rules ../panther-analysis`
- after the fix, I did the same in a different directory
- compared the two directories:
  ```
  ❯ diff --color=always --recursive -u before/ after/ 
  Only in after/.ruff_cache/0.4.10: 1079140530339041918
  Only in before/.ruff_cache/0.4.10: 11665568689874872365
  Only in before/.ruff_cache/0.4.10: 12975487684327146390
  Only in before/.ruff_cache/0.4.10: 15069057801861882113
  Only in before/.ruff_cache/0.4.10: 15203956785119599022
  Only in before/.ruff_cache/0.4.10: 15623221098896069416
  Only in after/.ruff_cache/0.4.10: 15702416295390398461
  Only in before/.ruff_cache/0.4.10: 16505075331491634122
  Only in after/.ruff_cache/0.4.10: 18154496484160029625
  Only in after/.ruff_cache/0.4.10: 2938993506692631706
  Only in after/.ruff_cache/0.4.10: 4787013320166684900
  Only in after/.ruff_cache/0.4.10: 9990206018046027959
  diff --color=always --recursive -u before/pypanther/rules/sublime/__init__.py after/pypanther/rules/sublime/__init__.py
  --- before/pypanther/rules/sublime/__init__.py	2025-01-13 12:02:19
  +++ after/pypanther/rules/sublime/__init__.py	2025-01-13 12:03:28
  @@ -1,8 +1,8 @@
  +from pypanther.rules.sublime.sublime_rules_deleted_or_deactivated import (
  +    SublimeRulesDeletedOrDeactivated as SublimeRulesDeletedOrDeactivated,
  +)
   from pypanther.rules.sublime.sublime_message_source_deleted_or_deactivated import (
       SublimeMessageSourceDeletedOrDeactivated as SublimeMessageSourceDeletedOrDeactivated,
  -)
  -from pypanther.rules.sublime.sublime_deleted_or_deactivated import (
  -    SublimeRulesDeletedOrDeactivated as SublimeRulesDeletedOrDeactivated,
   )
   from pypanther.rules.sublime.sublime_message_flagged import (
       SublimeMessageFlagged as SublimeMessageFlagged,
  Only in before/pypanther/rules/sublime: sublime_deleted_or_deactivated.py
  Only in after/pypanther/rules/sublime: sublime_rules_deleted_or_deactivated.py
  ```
- noticed that, after the fix, the name of the rules file remained unchanged, while the subdirectory changed as it should

<!-- pr guide: https://www.notion.so/pantherlabs/Github-Pull-Requests-PR-02af4e80f53844f985889d5c36874c6d#6a36878f77fb43a0b3539d93ee3c3da1 -->
<!-- reviewing guide: https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6 -->
