### PR TITLE
Fix Rule Deletion in generate.py

### DIFF
--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -1402,13 +1402,17 @@ def delete_rules(rules_path: Path, to_delete: list[str]) -> None:
 
     # delete empty directories or directories that contain only __init__.py files
     for root, dirs, files in os.walk(str(rules_path), topdown=False):
-        if len(dirs) == 0 and len(files) == 1 and files[0] == "__init__.py":
-            Path(os.path.join(root, files[0])).unlink()
+        # delete empty subdirectories
+        deleted_dirs = set()
         for name in dirs:
             directory = Path(os.path.join(root, name))
             if not any(directory.iterdir()):
                 # directory is empty
                 directory.rmdir()
+                deleted_dirs.add(name)
+        # if the directory contains only one __init__.py file, delete it
+        if len(set(dirs) - deleted_dirs) == 0 and len(files) == 1 and files[0] == "__init__.py":
+            Path(os.path.join(root, files[0])).unlink()
 
     # if the rules directory itself is empty, delete it
     if not any(rules_path.iterdir()):


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

<!-- more "the why" than "the what" -->

`generate.py` doesn't work well with deleting rule subdirectories without any rules (that's when it tries to detect only modified rules in panther-analysis).

### References: <!-- related links -->

<!-- relates to: JIRA Ticket # automation will link this PR to the JIRA -->
<!-- closes: JIRA Ticket # automation will link this PR to JIRA and close it -->

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

<!-- were relevant tests performed? Unit tests, E2E tests, etc
     Include steps you followed to test the changes as well as output of the tests
-->
<!-- reviewers should be able to understand how it was tested and have confidence in the change -->

- cloned latest panther-analysis main
- (didn't change anything there)
- before the fix, I converted the aforementioned panther-analysis directory with `pypanther convert --verbose ../panther-analysis`
- after the fix, I did the same
- comparing the results:
  ```
  ❯ diff --color=always --recursive -u before/ after/
  Only in before/content: rules
  ❯ tree before/content 
  before/content
  ├── __init__.py
  └── rules
      ├── __init__.py
      ├── crowdstrike
      │   └── __init__.py
      └── zscaler
          └── __init__.py
  
  4 directories, 4 files
  ❯ tree after/content 
  after/content
  └── __init__.py
  
  1 directory, 1 file
  ```
- before the fix, we have some empty directories while after the fix they're not generated

<!-- pr guide: https://www.notion.so/pantherlabs/Github-Pull-Requests-PR-02af4e80f53844f985889d5c36874c6d#6a36878f77fb43a0b3539d93ee3c3da1 -->
<!-- reviewing guide: https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6 -->
