### PR TITLE
Handle Custom Log types in generate.py

### DIFF
--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -110,13 +110,16 @@ def convert_rule(filepath: Path, helpers: Set[str]) -> Optional[str]:
         if k == "LogTypes":
             log_type_elts = []
             for x in v:
-                log_type_elts.append(
-                    ast.Attribute(
-                        value=ast.Name(id=f"{LogType.__name__}", ctx=ast.Load()),
-                        attr=LogType.get_attribute_name(x),
-                        ctx=ast.Load(),
-                    ),
-                )
+                if x.startswith("Custom."):
+                    log_type_elts.append(ast.Constant(value=x))
+                else:
+                    log_type_elts.append(
+                        ast.Attribute(
+                            value=ast.Name(id=f"{LogType.__name__}", ctx=ast.Load()),
+                            attr=LogType.get_attribute_name(x),
+                            ctx=ast.Load(),
+                        ),
+                    )
             value = ast.List(elts=log_type_elts)
         if k == "RuleID":
             value = ast.Constant(value=v + ID_POSTFIX)

--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -108,7 +108,7 @@ def convert_rule(filepath: Path, helpers: Set[str]) -> Optional[str]:
         if k == "Severity":
             value = ast.Name(id=f"{Severity.__name__}.{v.upper()}", ctx=ast.Load())
         if k == "LogTypes":
-            log_type_elts = []
+            log_type_elts: list[ast.expr] = []
             for x in v:
                 if x.startswith("Custom."):
                     log_type_elts.append(ast.Constant(value=x))


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

<!-- more "the why" than "the what" -->

We need to handle custom log types in `generate.py`.

### References: <!-- related links -->

<!-- relates to: JIRA Ticket # automation will link this PR to the JIRA -->
<!-- closes: JIRA Ticket # automation will link this PR to JIRA and close it -->

relates to: [EPD-1906](https://panther-labs.atlassian.net/browse/EPD-1906)

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

<!-- were relevant tests performed? Unit tests, E2E tests, etc
     Include steps you followed to test the changes as well as output of the tests
-->
<!-- reviewers should be able to understand how it was tested and have confidence in the change -->

- cloned panther-analysis main
- modified `rules/box_rules/box_new_login.yml` adding `Custom.MyRule` under `LogTypes`
- before the fix, running `pypanther convert --verbose ../panther-analysis` breaks
- after the fix, running `pypanther convert --verbose ../panther-analysis` results in the following:
  ```
  ❯ tree .
  .
  └── content
      ├── __init__.py
      └── overrides
          ├── __init__.py
          └── box.py
  
  3 directories, 3 files
  ❯ cat content/overrides/box.py 
  from pypanther import LogType
  from pypanther.rules.box import BoxNewLogin
  
  
  def apply_overrides():
      BoxNewLogin.override(log_types=[LogType.BOX_EVENT, "Custom.MyRule"])
  ```
- notice that the known log type is there as proper member of the respective enumeration while the unknown custom log type appears as a string

<!-- pr guide: https://www.notion.so/pantherlabs/Github-Pull-Requests-PR-02af4e80f53844f985889d5c36874c6d#6a36878f77fb43a0b3539d93ee3c3da1 -->
<!-- reviewing guide: https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6 -->


[EPD-1906]: https://panther-labs.atlassian.net/browse/EPD-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ