### PR TITLE
Avoid Marking Custom Rules as panther_managed in generate.py

### DIFF
--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -1499,6 +1499,7 @@ def delete_data_models(data_models_path: Path) -> None:
     shutil.rmtree(data_models_path)
 
 
+# currently, this function only removes the @panther_managed decorator from the class definitions of custom rules
 def fix_custom_rules(rules_path: Path, custom_rules: list[str]) -> None:
     for filename in custom_rules:
         possible_paths = list(rules_path.rglob(f"**/{filename}"))

--- a/pypanther/generate.py
+++ b/pypanther/generate.py
@@ -500,12 +500,7 @@ class DropClassDecorators(ast.NodeTransformer):
             return node
 
         new_decorator_list = [
-            x
-            for x in node.decorator_list
-            if not (
-                isinstance(x, ast.Name)
-                and x.id in self.decorator_names
-            )
+            x for x in node.decorator_list if not (isinstance(x, ast.Name) and x.id in self.decorator_names)
         ]
         return ast.ClassDef(
             name=node.name,
@@ -1550,7 +1545,9 @@ def convert(args: argparse.Namespace) -> tuple[int, str]:
         if keep_only_modified_rules:
             rules_path = Path("./pypanther/rules/")
             overrides_path = Path("./pypanther/overrides")
-            yaml_diff, python_diff, rules_to_delete, custom_rules = diff_rules_with_panther_analysis_main(panther_analysis)
+            yaml_diff, python_diff, rules_to_delete, custom_rules = diff_rules_with_panther_analysis_main(
+                panther_analysis,
+            )
             refactor_yaml_only_modified_rules(rules_path, overrides_path, yaml_diff)
             refactor_python_modified_rules(rules_path, python_diff)
             delete_rules(Path("./pypanther/rules/"), rules_to_delete)


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

<!-- more "the why" than "the what" -->

`generate.py` decorates **all** generated rule classes with the `@panther_managed` decorator which isn't correct for custom rules.

### References: <!-- related links -->

<!-- relates to: JIRA Ticket # automation will link this PR to the JIRA -->
<!-- closes: JIRA Ticket # automation will link this PR to JIRA and close it -->

relates to: [EPD-1907](https://panther-labs.atlassian.net/browse/EPD-1907)

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

<!-- were relevant tests performed? Unit tests, E2E tests, etc
     Include steps you followed to test the changes as well as output of the tests
-->
<!-- reviewers should be able to understand how it was tested and have confidence in the change -->

- cloned panther-analysis main
- added a custom rule under `rules/custom_rules/`
- before the fix, running `pypanther convert --verbose ../panther-analysis` produces the following:
  ```
  ❯ tree before/content 
  before/content
  ├── __init__.py
  └── rules
      ├── __init__.py
      └── custom
          ├── __init__.py
          └── my_rule.py
  
  3 directories, 4 files
  ❯ cat before/content/rules/custom/my_rule.py 
  from pypanther import Rule, Severity, LogType, panther_managed
  
  
  @panther_managed
  class MyRule(Rule):
      id = "My.Rule-prototype"
      display_name = "My Rule"
      log_types = [LogType.BOX_EVENT]
      default_severity = Severity.INFO
      create_alert = False
      default_description = "My Rule Description"
      default_runbook = "My Rule Runbook"
  
      def rule(self, event):
          return False
  
      def title(self, event):
          return "My rule"
  ```
- after the fix, running `pypanther convert --verbose ../panther-analysis` produces the following:
  ```
  ❯ tree after/content 
  after/content
  ├── __init__.py
  └── rules
      ├── __init__.py
      └── custom
          ├── __init__.py
          └── my_rule.py
  
  3 directories, 4 files
  ❯ cat after/content/rules/custom/my_rule.py 
  from pypanther import Rule, Severity, LogType, panther_managed
  
  
  class MyRule(Rule):
      id = "My.Rule-prototype"
      display_name = "My Rule"
      log_types = [LogType.BOX_EVENT]
      default_severity = Severity.INFO
      create_alert = False
      default_description = "My Rule Description"
      default_runbook = "My Rule Runbook"
  
      def rule(self, event):
          return False
  
      def title(self, event):
          return "My rule"
  ```
- also verified that running `python pypanther/generate.py --verbose --keep-all-rules ../panther-analysis` adds the `@panther_managed` decorator to other rule classes

<!-- pr guide: https://www.notion.so/pantherlabs/Github-Pull-Requests-PR-02af4e80f53844f985889d5c36874c6d#6a36878f77fb43a0b3539d93ee3c3da1 -->
<!-- reviewing guide: https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6 -->


[EPD-1907]: https://panther-labs.atlassian.net/browse/EPD-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ