### PR TITLE
Fixing license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Panther Labs Inc <pypi@runpanther.io>"]
 readme = "README.md"
 keywords = ["Security", "CLI"]
 classifiers = ["Operating System :: OS Independent"]
-license = "AGPL-3.0-only"
+license = "Apache-2.0"
 include = ["pypanther/py.typed"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

Seeing license of pypi package to Apache 2.0. Currently while the code is listed as Apache 2.0 the package is AGPL 3.0 as  an be seen [here](https://pypi.org/project/pypanther/0.1.1a54/). 

### References: <!-- related links -->

Closes: https://panther-labs.atlassian.net/browse/EPD-2273

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

High. List of annotations can be seen in poetry's documentation: https://python-poetry.org/docs/pyproject/?utm_source=chatgpt.com#license