### PR TITLE
Schema changes should be case-insensitive

### DIFF
--- a/pypanther/schemas.py
+++ b/pypanther/schemas.py
@@ -242,7 +242,7 @@ class Manager:
 
         """
         for schema in self.existing_upstream_schemas:
-            if schema.name == name:
+            if schema.name.casefold() == name.casefold():
                 return schema
         return None
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -160,7 +160,7 @@ class TestUploader(unittest.TestCase):
                         created_at="2021-05-11T14:08:08.42627193Z",
                         description="A verbose description",
                         is_managed=False,
-                        name="Custom.SAMPLESchema1", # Name has upper case letters deliberately
+                        name="Custom.SAMPLESchema1",  # Name has upper case letters deliberately
                         reference_url="https://example.com",
                         revision=17,
                         spec=self.valid_schema1,
@@ -193,7 +193,7 @@ class TestUploader(unittest.TestCase):
             ),
         )
         self.put_schema_response = lambda: Schema(
-            name="Custom.SAMPLESchema1", # Name has upper case letters deliberately
+            name="Custom.SAMPLESchema1",  # Name has upper case letters deliberately
             revision=18,
             updated_at="2021-05-17T10:34:18.192993496Z",
             created_at="2021-05-17T10:15:38.18907328Z",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -160,7 +160,7 @@ class TestUploader(unittest.TestCase):
                         created_at="2021-05-11T14:08:08.42627193Z",
                         description="A verbose description",
                         is_managed=False,
-                        name="Custom.SampleSchema1",
+                        name="Custom.SAMPLESchema1", # Name has upper case letters deliberately
                         reference_url="https://example.com",
                         revision=17,
                         spec=self.valid_schema1,
@@ -193,8 +193,8 @@ class TestUploader(unittest.TestCase):
             ),
         )
         self.put_schema_response = lambda: Schema(
-            name="Custom.SampleSchema1",
-            revision=0,
+            name="Custom.SAMPLESchema1", # Name has upper case letters deliberately
+            revision=18,
             updated_at="2021-05-17T10:34:18.192993496Z",
             created_at="2021-05-17T10:15:38.18907328Z",
             description="",


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

Customers noticed some errors while trying to use `update-custom-schemas` command. 
Turns out it was due to case errors.
Backend already is able to correctly _ignore_ case differences. The error was manifesting due to `revision` conflicts, (because the CLI thought that the schema is new it sent `revision=0`, but the schema existed with `revision > 1+`)

### References: <!-- related links -->

Closes https://panther-labs.atlassian.net/browse/EPD-2289
Closes https://panther-labs.atlassian.net/browse/ASK-1231

[Same as this PAT change](https://github.com/panther-labs/panther_analysis_tool/pull/562)

## Confidence

### Before

![image](https://github.com/user-attachments/assets/a958131f-cde9-47d4-bb24-30f33b25e747)

### After

![image](https://github.com/user-attachments/assets/63c34f83-a9b3-43a7-b244-854e9e31a3e1)

### with schema being
![image](https://github.com/user-attachments/assets/66cb729a-6f59-4c4c-ab42-a3a5c671e47e)

### while at the UI is

![image](https://github.com/user-attachments/assets/5e3b6962-e13e-4a04-8825-339912086981)

**and change went thru w/o changing the original name in the db**