### PR TITLE
Jn/duplicate change summary

### DIFF
--- a/pypanther/testing.py
+++ b/pypanther/testing.py
@@ -315,7 +315,7 @@ def print_test_summary(test_results: TestResults) -> None:
     passed_mgd_rules_msg = f"({num_passed_mgd_rules} panther managed)" if num_passed_mgd_rules > 0 else ""
     failed_mgd_rules_msg = f"({num_failed_mgd_rules} panther managed)" if num_failed_mgd_rules > 0 else ""
 
-    print(cli_output.header("Test Summary") + ":")
+    print(cli_output.header("Test Summary"))
 
     print(INDENT, f"Skipped rules: {test_results.num_skipped_rules():>3}", skipped_mgd_rules_msg)
     print(INDENT, f"Passed rules:  {test_results.num_passed_rules():>3}", passed_mgd_rules_msg)

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -467,32 +467,39 @@ def print_upload_detection_error(err: BulkUploadDetectionsError) -> None:
 
 
 def print_changes_summary(changes_summary: ChangesSummary) -> None:
-    print("Changes Summary:")
-    print()  # new line
-    if changes_summary["new_rule_ids"]:
-        print(f"New Rules [{len(changes_summary['new_rule_ids'])}]:")
-        for id_ in changes_summary["new_rule_ids"]:
-            print(f"+ {id_}")
+    # Check if any of the keys starting with new/delete/modify have a value greater than 0
+    if (changes_summary["new_rule_ids"] or
+        changes_summary["delete_rule_ids"] or
+        changes_summary["modify_rule_ids"] or
+        changes_summary["new_schema_names"] or
+        changes_summary["modified_schema_names"]):
+        print(cli_output.header("Changes"))
         print()  # new line
-    if changes_summary["delete_rule_ids"]:
-        print(f"Delete Rules [{len(changes_summary['delete_rule_ids'])}]:")
-        for id_ in changes_summary["delete_rule_ids"]:
-            print(f"- {id_}")
-        print()  # new line
-    if changes_summary["modify_rule_ids"]:
-        print(f"Modify Rules [{len(changes_summary['modify_rule_ids'])}]:")
-        for id_ in changes_summary["modify_rule_ids"]:
-            print(f"~ {id_}")
-        print()  # new line
-    if changes_summary["new_schema_names"]:
-        print(f"New Schemas [{len(changes_summary['new_schema_names'])}]:")
-        for name in changes_summary["new_schema_names"]:
-            print(f"+ {name}")
-        print()  # new line
-    if changes_summary["modified_schema_names"]:
-        print(f"Modify Schemas [{len(changes_summary['modified_schema_names'])}]:")
-        for name in changes_summary["modified_schema_names"]:
-            print(f"~ {name}")
+        if changes_summary["new_rule_ids"]:
+            print(f"New Rules [{len(changes_summary['new_rule_ids'])}]:")
+            for id_ in changes_summary["new_rule_ids"]:
+                print(f"+ {id_}")
+            print()  # new line
+        if changes_summary["delete_rule_ids"]:
+            print(f"Delete Rules [{len(changes_summary['delete_rule_ids'])}]:")
+            for id_ in changes_summary["delete_rule_ids"]:
+                print(f"- {id_}")
+            print()  # new line
+        if changes_summary["modify_rule_ids"]:
+            print(f"Modify Rules [{len(changes_summary['modify_rule_ids'])}]:")
+            for id_ in changes_summary["modify_rule_ids"]:
+                print(f"~ {id_}")
+            print()  # new line
+        if changes_summary["new_schema_names"]:
+            print(f"New Schemas [{len(changes_summary['new_schema_names'])}]:")
+            for name in changes_summary["new_schema_names"]:
+                print(f"+ {name}")
+            print()  # new line
+        if changes_summary["modified_schema_names"]:
+            print(f"Modify Schemas [{len(changes_summary['modified_schema_names'])}]:")
+            for name in changes_summary["modified_schema_names"]:
+                print(f"~ {name}")
+
     print(cli_output.header("Changes Summary"))
     print(INDENT, f"New Rules:      {len(changes_summary['new_rule_ids']):>4}")
     print(INDENT, f"Modified Rules: {len(changes_summary['modify_rule_ids']):>4}")

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -468,11 +468,13 @@ def print_upload_detection_error(err: BulkUploadDetectionsError) -> None:
 
 def print_changes_summary(changes_summary: ChangesSummary) -> None:
     # Check if any of the keys starting with new/delete/modify have a value greater than 0
-    if (changes_summary["new_rule_ids"] or
-        changes_summary["delete_rule_ids"] or
-        changes_summary["modify_rule_ids"] or
-        changes_summary["new_schema_names"] or
-        changes_summary["modified_schema_names"]):
+    if (
+        changes_summary["new_rule_ids"]
+        or changes_summary["delete_rule_ids"]
+        or changes_summary["modify_rule_ids"]
+        or changes_summary["new_schema_names"]
+        or changes_summary["modified_schema_names"]
+    ):
         print(cli_output.header("Changes"))
         print()  # new line
         if changes_summary["new_rule_ids"]:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -274,7 +274,7 @@ class TestPrintTestSummary:
         testing.print_test_summary(test_results)
 
         exp = (
-            "\x1b[95mTest Summary\x1b[0m:\n"
+            "\x1b[95mTest Summary\x1b[0m\n"
             "   Skipped rules:   1 \n"
             "   Passed rules:    0 \n"
             "   \x1b[4mFailed rules:    0\x1b[0m \n"
@@ -298,7 +298,7 @@ class TestPrintTestSummary:
         testing.print_test_summary(test_results)
 
         exp = (
-            "\x1b[95mTest Summary\x1b[0m:\n"
+            "\x1b[95mTest Summary\x1b[0m\n"
             "   Skipped rules:   0 \n"
             "   Passed rules:    1 \n"
             "   \x1b[4mFailed rules:    0\x1b[0m \n"
@@ -322,7 +322,7 @@ class TestPrintTestSummary:
         testing.print_test_summary(test_results)
 
         exp = (
-            "\x1b[95mTest Summary\x1b[0m:\n"
+            "\x1b[95mTest Summary\x1b[0m\n"
             "   Skipped rules:   1 \n"
             "   Passed rules:    0 \n"
             "   \x1b[4mFailed rules:    2\x1b[0m \n"


### PR DESCRIPTION
### Description

Minor UX fixes to the CLI! 

"Change Summary" was showing up twice, once with stats and once showing the exact IDs. The issue is that if there were no creation, modify, or deleted resources, it'd show an empty Change Summary, followed by a second one.

### References:

No ticket, just a PR

### Confidence: Tested all scenarios

Before:
![Screenshot 2025-03-04 at 2 56 11 PM](https://github.com/user-attachments/assets/fac07c64-33b0-4db1-86df-69752355ac7d)
![Screenshot 2025-03-04 at 2 51 23 PM](https://github.com/user-attachments/assets/33d14e94-b842-4c8f-bce8-a85ed92da1d2)

After:
![Screenshot 2025-03-04 at 2 53 18 PM](https://github.com/user-attachments/assets/5a12ceed-9db4-4eeb-969c-2585e84536a1)
![Screenshot 2025-03-04 at 2 52 11 PM](https://github.com/user-attachments/assets/7f1f3b8f-b897-43bc-bc0f-69384bced9b5)
