### PR TITLE
Removing confirmation

### DIFF
--- a/pypanther/get_rule.py
+++ b/pypanther/get_rule.py
@@ -12,7 +12,7 @@ def run(args: argparse.Namespace) -> Tuple[int, str]:
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
-        return 1, "No main.py found."
+        return 1, "No main.py found. Are you running this command from the root of your pypanther project?"
     found_rules = set(get_panther_rules(id=args.id)).union(registered_rules(id=args.id))
     if len(found_rules) == 0:
         return 1, f"Found no rules matching id={args.id}"

--- a/pypanther/setup_subparsers.py
+++ b/pypanther/setup_subparsers.py
@@ -101,13 +101,6 @@ def setup_upload_parser(upload_parser: argparse.ArgumentParser):
         action="store_true",
     )
     upload_parser.add_argument(
-        "--confirm",
-        help="Proceed with the upload without requiring user input",
-        default=False,
-        required=False,
-        action="store_true",
-    )
-    upload_parser.add_argument(
         "--verbose",
         help="Verbose output",
         default=False,

--- a/pypanther/testing.py
+++ b/pypanther/testing.py
@@ -106,7 +106,7 @@ def run(args: argparse.Namespace) -> Tuple[int, str]:
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
-        logging.error("No main.py found")  # noqa: TRY400
+        logging.error("No main.py found. Are you running this command from the root of your pypanther project?")  # noqa: TRY400
         return 1, ""
 
     test_results = run_tests(args)

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -61,14 +61,7 @@ class ChangesSummary(TypedDict):
 
 
 def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
-    if not args.confirm:
-        err = confirm(
-            "WARNING: pypanther upload is under active development and not recommended for use"
-            " without guidance from the Panther team. Would you like to proceed? [y/n]: ",
-        )
-        if err is not None:
-            return 0, ""
-
+    cli_output.warning("WARNING: pypanther is a beta feature and is subject to breaking changes before general availability")
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
@@ -181,9 +174,9 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
             else:
                 print_changes_summary(changes_summary)
 
-        if not args.skip_summary and not args.confirm and not args.dry_run:
+        if not args.skip_summary and not args.dry_run:
             # if the user skips calculating the summary of the changes,
-            # "--confirm" has no effect, as there's no info to act upon
+            # there's no information to act upon for confirmation
             err = confirm("Would you like to make this change? [y/n]: ")
             if err is not None:
                 return 0, ""

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -176,7 +176,7 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
 
         if not args.skip_summary and not args.dry_run:
             # if the user skips calculating the summary of the changes,
-            # there's no information to act upon for confirmation
+            # we don't show a message since there's no information shared with the user to act upon
             err = confirm("Would you like to make this change? [y/n]: ")
             if err is not None:
                 return 0, ""

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -61,7 +61,11 @@ class ChangesSummary(TypedDict):
 
 
 def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
-    print(cli_output.warning("WARNING: pypanther is in beta and is subject to breaking changes before general availability"))
+    print(
+        cli_output.warning(
+            "WARNING: pypanther is in beta and is subject to breaking changes before general availability",
+        ),
+    )
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -61,11 +61,11 @@ class ChangesSummary(TypedDict):
 
 
 def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
-    cli_output.warning("WARNING: pypanther is a beta feature and is subject to breaking changes before general availability")
+    print(cli_output.warning("WARNING: pypanther is in beta and is subject to breaking changes before general availability"))
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
-        logging.error("No main.py found")  # noqa: TRY400
+        logging.error("No main.py found. Are you running this command from the root of your pypanther project?")  # noqa: TRY400
         return 1, ""
 
     test_results = testing.TestResults()


### PR DESCRIPTION
### Description: <!-- why was this change made? -->

@jacknagz  mentioned that we shouldn't really need the confirmation every time (at this point, customers are just passing `--confirm` by default). 

Removing it and replacing with suggested text. 

### References: <!-- related links -->

### Confidence: <!-- what testing was done to ensure the change does what it is intended to do? -->

## `pypanther upload` ✅ 

<img width="743" alt="Screenshot 2025-03-06 at 15 33 47" src="https://github.com/user-attachments/assets/c648a9f4-bae6-43b0-9110-08f763c28f76" />

## `pypanther upload --skip-summary` ✅ 

<img width="735" alt="Screenshot 2025-03-06 at 15 34 11" src="https://github.com/user-attachments/assets/1996c99e-be59-4228-ab42-16452ddf2d6f" />
