### PR TITLE
Printing version of pypanther during upload

### DIFF
--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -111,7 +111,13 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
             print_included_files(zip_info)
 
         try:
-            session_id = upload_zip(backend=backend, archive=tmp.name, verbose=args.verbose, output_type=args.output, pypanther_version=pypanther_version)
+            session_id = upload_zip(
+                backend=backend,
+                archive=tmp.name,
+                verbose=args.verbose,
+                output_type=args.output,
+                pypanther_version=pypanther_version,
+            )
         except BackendError as be_err:
             multi_err = BulkUploadDetectionsError.from_json(convert_unicode(be_err))
             if args.output == display.OUTPUT_TYPE_TEXT:
@@ -439,7 +445,11 @@ def print_included_files(zip_info: list[zipfile.ZipInfo]) -> None:
     print()  # new line
 
 
-def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary, pypanther_version: str) -> None:
+def print_upload_statistics(
+    rule_results: BulkUploadDetectionsResults,
+    schema_results: ChangesSummary,
+    pypanther_version: str,
+) -> None:
     print(cli_output.header("Upload Statistics"))
 
     print(INDENT, f"{cli_output.bold('PyPanther Version:')} {pypanther_version}")

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -66,6 +66,8 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
             "WARNING: pypanther is in beta and is subject to breaking changes before general availability",
         ),
     )
+
+    
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
@@ -95,6 +97,8 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
     if args.verbose and args.output == display.OUTPUT_TYPE_TEXT:
         print_registered_rules()
 
+    pypanther_version = importlib.metadata.version("pypanther")
+
     with tempfile.NamedTemporaryFile() as tmp:
         zip_info = zip_contents(tmp)
         zip_size = Path.stat(Path(tmp.name)).st_size
@@ -109,7 +113,7 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
             print_included_files(zip_info)
 
         try:
-            session_id = upload_zip(backend=backend, archive=tmp.name, verbose=args.verbose, output_type=args.output)
+            session_id = upload_zip(backend=backend, archive=tmp.name, verbose=args.verbose, output_type=args.output, pypanther_version=pypanther_version)
         except BackendError as be_err:
             multi_err = BulkUploadDetectionsError.from_json(convert_unicode(be_err))
             if args.output == display.OUTPUT_TYPE_TEXT:
@@ -227,7 +231,7 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
         )
         print(json.dumps(output, indent=display.JSON_INDENT_LEVEL))
     else:
-        print_upload_statistics(rule_upload_stats, changes_summary)
+        print_upload_statistics(rule_upload_stats, changes_summary, pypanther_version)
 
     return 0, ""
 
@@ -320,12 +324,12 @@ def upload_zip(
     archive: str,
     verbose: bool,
     output_type: str,
+    pypanther_version: str,
 ) -> str:
     if verbose and output_type == display.OUTPUT_TYPE_TEXT:
         print("requesting presigned URL for upload")
         print()
 
-    pypanther_version = importlib.metadata.version("pypanther")
     response = backend.bulk_upload_presigned_url(
         params=BulkUploadPresignedURLParams(pypanther_version=pypanther_version),
     )
@@ -370,6 +374,7 @@ def get_upload_output_as_dict(
     changes_summary: ChangesSummary | None,
 ) -> dict:
     output: dict[str, Any] = {"result": upload_result}
+    
     if upload_stats:
         schema_stats = {}
         if changes_summary:
@@ -437,11 +442,10 @@ def print_included_files(zip_info: list[zipfile.ZipInfo]) -> None:
     print()  # new line
 
 
-def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary) -> None:
+def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary, pypanther_version: str) -> None:
     print(cli_output.header("Upload Statistics"))
 
     # Add pypanther version information
-    pypanther_version = importlib.metadata.version("pypanther")
     print(INDENT, f"{cli_output.bold('PyPanther Version:')} {pypanther_version}")
     print()  # new line
 

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -442,7 +442,7 @@ def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_re
     
     # Add pypanther version information
     pypanther_version = importlib.metadata.version("pypanther")
-    print(INDENT, cli_output.bold(f"PyPanther Version: {pypanther_version}"))
+    print(INDENT, f"{cli_output.bold('PyPanther Version:')} {pypanther_version}")
     print()  # new line
     
     print(INDENT, cli_output.bold("Rules:"))

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -439,6 +439,12 @@ def print_included_files(zip_info: list[zipfile.ZipInfo]) -> None:
 
 def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary) -> None:
     print(cli_output.header("Upload Statistics"))
+    
+    # Add pypanther version information
+    pypanther_version = importlib.metadata.version("pypanther")
+    print(INDENT, f"PyPanther Version: {pypanther_version}")
+    print()  # new line
+    
     print(INDENT, cli_output.bold("Rules:"))
     print(INDENT * 2, "{:<9} {:>4}".format("New:      ", len(rule_results.new_rule_ids)))
     print(INDENT * 2, "{:<9} {:>4}".format("Modified: ", len(rule_results.modified_rule_ids)))

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -439,12 +439,12 @@ def print_included_files(zip_info: list[zipfile.ZipInfo]) -> None:
 
 def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary) -> None:
     print(cli_output.header("Upload Statistics"))
-    
+
     # Add pypanther version information
     pypanther_version = importlib.metadata.version("pypanther")
     print(INDENT, f"{cli_output.bold('PyPanther Version:')} {pypanther_version}")
     print()  # new line
-    
+
     print(INDENT, cli_output.bold("Rules:"))
     print(INDENT * 2, "{:<9} {:>4}".format("New:      ", len(rule_results.new_rule_ids)))
     print(INDENT * 2, "{:<9} {:>4}".format("Modified: ", len(rule_results.modified_rule_ids)))

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -442,7 +442,7 @@ def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_re
     
     # Add pypanther version information
     pypanther_version = importlib.metadata.version("pypanther")
-    print(INDENT, f"PyPanther Version: {pypanther_version}")
+    print(INDENT, cli_output.bold(f"PyPanther Version: {pypanther_version}"))
     print()  # new line
     
     print(INDENT, cli_output.bold("Rules:"))

--- a/pypanther/upload.py
+++ b/pypanther/upload.py
@@ -66,8 +66,6 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
             "WARNING: pypanther is in beta and is subject to breaking changes before general availability",
         ),
     )
-
-    
     try:
         import_main(os.getcwd(), "main")
     except NoMainModuleError:
@@ -374,7 +372,6 @@ def get_upload_output_as_dict(
     changes_summary: ChangesSummary | None,
 ) -> dict:
     output: dict[str, Any] = {"result": upload_result}
-    
     if upload_stats:
         schema_stats = {}
         if changes_summary:
@@ -445,7 +442,6 @@ def print_included_files(zip_info: list[zipfile.ZipInfo]) -> None:
 def print_upload_statistics(rule_results: BulkUploadDetectionsResults, schema_results: ChangesSummary, pypanther_version: str) -> None:
     print(cli_output.header("Upload Statistics"))
 
-    # Add pypanther version information
     print(INDENT, f"{cli_output.bold('PyPanther Version:')} {pypanther_version}")
     print()  # new line
 


### PR DESCRIPTION
### Description

More than once we have been contacted from customers that thought they were using a particular version of PyPanther in the CI/CD tool... but it turned out they were not. 

To reduces the chances for confusion, this PR updates the `pypanther upload` command to print the PyPanther version on successful update. 

### Checklist

- [ ] Added unit tests
- [x] Tested end to end, including screenshots or videos
<img width="765" alt="Screenshot 2025-03-07 at 15 30 39" src="https://github.com/user-attachments/assets/d483f580-6794-4d36-8d91-0334fac8b559" />


### Notes for Reviewing

Let me know if the wording and style of output makes sense. 
