### PR TITLE
Revert "Revert "[EPD-2449] Fail in case of multiple registered rules …

### DIFF
--- a/pypanther/registry.py
+++ b/pypanther/registry.py
@@ -33,9 +33,14 @@ def register(arg: Type[Rule] | Type[DataModel] | Iterable[Type[Rule] | Type[Data
 
 
 def _register_rule(rule: Type[Rule]) -> bool:
-    """Register a rule with the pypanther library. Returns True if the rule was registered, False otherwise."""
+    """
+    Register a rule with the pypanther library. Returns True if the argument was a rule False otherwise.
+    If a rule with the same id is already registered, a ValueError is raised.
+    """
     if isinstance(rule, type) and issubclass(rule, Rule):
         rule.validate()
+        if rule.id in set(r.id for r in _RULE_REGISTRY):
+            raise ValueError(f"Rule with id '{rule.id}' is already registered")
         _RULE_REGISTRY.add(rule)
         return True
     return False

--- a/tests/test_list_rules.py
+++ b/tests/test_list_rules.py
@@ -6,6 +6,7 @@ import pytest
 
 from pypanther import list_rules
 from pypanther.main import setup_parser
+from pypanther.registry import _RULE_REGISTRY
 
 LIST_RULES_CMD = "list rules"
 FILTER_ARGS = [
@@ -34,6 +35,7 @@ FILTER_ARGS = [
 
 
 def test_list_default() -> None:
+    _RULE_REGISTRY.clear()
     with create_main():
         args = setup_parser().parse_args(f"{LIST_RULES_CMD}".split(" "))
         assert not args.managed
@@ -43,6 +45,7 @@ def test_list_default() -> None:
 
 
 def test_list_with_more_than_all() -> None:
+    _RULE_REGISTRY.clear()
     with create_main():
         args = setup_parser().parse_args(f"{LIST_RULES_CMD} --attributes all log_types".split(" "))
         code, err = list_rules.run(args)
@@ -51,6 +54,7 @@ def test_list_with_more_than_all() -> None:
 
 
 def test_list_with_all() -> None:
+    _RULE_REGISTRY.clear()
     with create_main():
         args = setup_parser().parse_args(f"{LIST_RULES_CMD} --attributes all".split(" "))
         code, err = list_rules.run(args)
@@ -60,6 +64,7 @@ def test_list_with_all() -> None:
 
 @pytest.mark.parametrize("cmd", [f"{LIST_RULES_CMD} --managed true {f}" for f in FILTER_ARGS])
 def test_list_managed_rules(cmd: str) -> None:
+    _RULE_REGISTRY.clear()
     args = setup_parser().parse_args(cmd.split(" "))
     code, err = list_rules.run(args)
     assert code == 0

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,7 +5,12 @@ import pytest
 from pypanther import LogType, register
 from pypanther.base import Rule, Severity
 from pypanther.data_models_v2 import DataModel
-from pypanther.registry import _DATA_MODEL_REGISTRY, _RULE_REGISTRY, registered_data_models, registered_rules
+from pypanther.registry import (
+    _DATA_MODEL_REGISTRY,
+    _RULE_REGISTRY,
+    registered_data_models,
+    registered_rules,
+)
 
 
 class RuleA(Rule):
@@ -55,15 +60,33 @@ class TestRegister(unittest.TestCase):
 
     def test_register_rule_duplicate(self):
         register(RuleA)
-        RuleA.tags.append("test2")
-        register(RuleA)
-        assert len(registered_rules()) == 1
-        assert RuleA in registered_rules()
+        with pytest.raises(ValueError, match="Rule with id 'rule_a' is already registered"):
+            register(RuleA)
 
     def test_register_rule_duplicate_in_list(self):
-        register([RuleA, RuleA])
-        assert len(registered_rules()) == 1
-        assert RuleA in registered_rules()
+        with pytest.raises(ValueError, match="Rule with id 'rule_a' is already registered"):
+            register([RuleA, RuleA])
+
+    def test_register_rule_duplicate_id(self):
+        class RuleA(Rule):
+            log_types = [LogType.OKTA_SYSTEM_LOG]
+            id = "rule_1"
+            default_severity = Severity.INFO
+
+            def rule(self, _):
+                pass
+
+        class RuleB(Rule):
+            log_types = [LogType.OKTA_SYSTEM_LOG]
+            id = "rule_1"
+            default_severity = Severity.INFO
+
+            def rule(self, _):
+                pass
+
+        with pytest.raises(ValueError, match="Rule with id 'rule_1' is already registered"):
+            register(RuleA)
+            register(RuleB)
 
     def test_register_rules(self):
         register([RuleA, RuleB])
@@ -163,6 +186,7 @@ class TestRegisteredRules:
         )
 
     def test_no_args(self) -> None:
+        _RULE_REGISTRY.clear()
         to_register = {RuleA, RuleB}
         register(to_register)
         registered = registered_rules()
@@ -187,6 +211,7 @@ class TestRegisteredRules:
 
     @pytest.mark.parametrize("kwarg_a", kwargs_a, ids=lambda x: str(next(iter(x))))
     def test_filter(self, kwarg_a) -> None:
+        _RULE_REGISTRY.clear()
         to_register = {RuleA, RuleB}
         register(to_register)
         registered = registered_rules(**kwarg_a)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -11,6 +11,7 @@ from pypanther.base import Rule, RuleTest, Severity
 from pypanther.cache import data_model_cache
 from pypanther.log_types import LogType
 from pypanther.main import setup_parser
+from pypanther.registry import _RULE_REGISTRY
 
 get_data_model = data_model_cache().data_model_of_logtype
 
@@ -567,6 +568,7 @@ class TestRun:
 
     @pytest.mark.parametrize("cmd", [f"test {f}" for f in FILTER_ARGS])
     def test_test_filters(self, cmd: str) -> None:
+        _RULE_REGISTRY.clear()
         with create_main():
             args = setup_parser().parse_args(cmd.split(" "))
             code, result = testing.run(args)


### PR DESCRIPTION
…with same ID (#198)" (#219)"

This reverts commit 04e6c11bf6bc159d4f38bc665c730070eec07a24.

### Description

Reverting the revert - failing in trying to register two rules with same ID. Before we were allowing multiple rules with the same ID to exist in registry, each with different logic and all would eventually run in the log processor. 
ID are meant to be unique though. 

### References

JIRA Ticket Link:

### Checklist

- [x] Added unit tests
- [x] Tested end to end, including screenshots or videos

I was able to upload the pypanthet starter kit without issues. 

### Notes for Reviewing

Testing steps to help reviewers test code. Include any Feature Flags or Pulumi Configs needed to test.

[Reviewing Guidelines](https://www.notion.so/pantherlabs/Reviewing-Pull-Requests-64b9f85c4e7b47128d1b2dd160330ae6)
