### PR TITLE
pypanther test should fail in case a rule has multiple tests with the same name

### DIFF
--- a/pypanther/base.py
+++ b/pypanther/base.py
@@ -366,7 +366,7 @@ class Rule(metaclass=abc.ABCMeta):
         test_names_seen = set()
         for test in cls.tests:
             if test.name in test_names_seen:
-                raise ValueError(f"Rule {cls.id} has multiple tests with the same name: {test.name}")
+                raise ValueError(f"Rule ({cls.id}) has multiple tests with the same name ({test.name})")
             test_names_seen.add(test.name)
 
         if test_names is None:

--- a/pypanther/base.py
+++ b/pypanther/base.py
@@ -346,9 +346,21 @@ class Rule(metaclass=abc.ABCMeta):
         _validate_config: bool = True,
         test_names: Optional[List[str]] = None,
     ) -> list[RuleTestResult]:
-        """Run all tests for this rule."""
-        if _validate_config:
-            cls.validate_config()
+        """
+        Runs all RuleTests in this Rules' Test attribute over this Rule.
+
+        Parameters
+        ----------
+            get_data_model: a helper function that will return a DataModel given a log type.
+            _validate_config: true if tests are being run should validate any configuration, false otherwise. Only meant to be used by Panther.
+            test_names: if provided, the names of the tests on the rule to run, otherwise run all tests
+
+        Returns
+        -------
+            a list of RuleTestResult objects.
+
+        """
+        cls.validate(_validate_config)
 
         # Check for duplicate test names
         test_names_seen = set()

--- a/pypanther/base.py
+++ b/pypanther/base.py
@@ -362,7 +362,7 @@ class Rule(metaclass=abc.ABCMeta):
         """
         cls.validate(_validate_config)
 
-        # Check for duplicate test names
+        # Check for duplicate test names on the Rule before running any tests
         test_names_seen = set()
         for test in cls.tests:
             if test.name in test_names_seen:

--- a/pypanther/base.py
+++ b/pypanther/base.py
@@ -266,11 +266,6 @@ class Rule(metaclass=abc.ABCMeta):
     def validate(cls) -> None:
         """
         Validates this PantherRule.
-
-        Parameters
-        ----------
-            _validate_config: true if any configuration should be validated, false otherwise. Only meant to be used by Panther.
-
         """
         RuleAdapter.validate_python(cls.asdict())
         cls.validate_config()
@@ -357,7 +352,6 @@ class Rule(metaclass=abc.ABCMeta):
         Parameters
         ----------
             get_data_model: a helper function that will return a DataModel given a log type.
-            _validate_config: true if tests are being run should validate any configuration, false otherwise. Only meant to be used by Panther.
             test_names: if provided, the names of the tests on the rule to run, otherwise run all tests
 
         Returns

--- a/pypanther/rules/github/github_repo_vulnerability_dismissed.py
+++ b/pypanther/rules/github/github_repo_vulnerability_dismissed.py
@@ -25,15 +25,6 @@ class GithubRepoVulnerabilityDismissed(Rule):
 
     tests = [
         RuleTest(
-            name="GitHub Dependabot Vulnerability Dismissed",
-            expected_result=True,
-            log={
-                "action": "repository_vulnerability_alert.dismiss",
-                "alert_number": 1,
-                "repo": "panther-labs/panther-analysis",
-            },
-        ),
-        RuleTest(
             name="Not GitHub Dependabot Vulnerability Dismissed",
             expected_result=False,
             log={"action": "not_repository_vulnerability_alert.dismiss"},

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -368,7 +368,7 @@ class TestRunningTests:
 
         with pytest.raises(
             ValueError,
-            match="Rule RuleWithDuplicateTests has multiple tests with the same name: same_name",
+            match=r"Rule \(RuleWithDuplicateTests\) has multiple tests with the same name \(same_name\)",
         ):
             RuleWithDuplicateTests.run_tests(get_data_model)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -351,6 +351,25 @@ class TestRunningTests:
         results = Rule1.run_tests(get_data_model, test_names=[])
         assert len(results) == 0
 
+    def test_duplicate_test_names_raise_error(self):
+        """Test that rules with duplicate test names raise a ValueError."""
+
+        class RuleWithDuplicateTests(Rule):
+            log_types = [LogType.PANTHER_AUDIT]
+            default_severity = Severity.HIGH
+            id = "RuleWithDuplicateTests"
+            tests = [
+                RuleTest(name="same_name", expected_result=True, log={}),
+                RuleTest(name="same_name", expected_result=False, log={}),
+            ]
+
+            def rule(self, event):
+                return True
+
+        with pytest.raises(ValueError) as exc_info:
+            RuleWithDuplicateTests.run_tests(get_data_model)
+        assert str(exc_info.value) == "Rule RuleWithDuplicateTests has multiple tests with the same name: same_name"
+
 
 class TestValidation:
     def test_rule_missing_id(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -366,9 +366,11 @@ class TestRunningTests:
             def rule(self, event):
                 return True
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(
+            ValueError,
+            match="Rule RuleWithDuplicateTests has multiple tests with the same name: same_name",
+        ):
             RuleWithDuplicateTests.run_tests(get_data_model)
-        assert str(exc_info.value) == "Rule RuleWithDuplicateTests has multiple tests with the same name: same_name"
 
 
 class TestValidation:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -370,7 +370,7 @@ class TestRunningTests:
             ValueError,
             match=r"Rule \(RuleWithDuplicateTests\) has multiple tests with the same name \(same_name\)",
         ):
-            RuleWithDuplicateTests.run_tests(get_data_model)
+            RuleWithDuplicateTests.validate()
 
 
 class TestValidation:
@@ -1407,33 +1407,6 @@ class TestRule(TestCase):
         )
         assert result.detection_result.destinations_exception is None
         assert result.detection_result.destinations_output == []
-
-    def test_validate_internal_does_not_fail(self) -> None:
-        class MyRule(Rule):
-            id = "MyRule"
-            default_severity = Severity.INFO
-            log_types = [LogType.PANTHER_AUDIT]
-
-            allowed_domains: list[str] = []
-
-            tests = [
-                RuleTest(
-                    name="domain max",
-                    expected_result=False,
-                    log={"domain": "max.com"},
-                ),
-            ]
-
-            def rule(self, event):
-                return event.get("domain") in self.allowed_domains
-
-            @classmethod
-            def validate_config(cls):
-                assert (
-                    len(cls.allowed_domains) > 0
-                ), "The allowed_domains field on your PantherOOTBRule must be populated before using this rule"
-
-        assert MyRule().run_tests(get_data_model, _validate_config=False)[0].passed
 
     def test_validate_external_fails(self) -> None:
         class MyRule(Rule):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -13,7 +13,7 @@ def test_rule(rule: Type[Rule]):
     if hasattr(rule, "_tests"):
         rule.tests = rule._tests
 
-    for result in rule.run_tests(data_model_cache().data_model_of_logtype, _validate_config=False):
+    for result in rule.run_tests(data_model_cache().data_model_of_logtype):
         assert result.passed
 
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -157,14 +157,14 @@ class TestPrintRuleTestResults:
     def test_both_pass_and_fail(self, capsys) -> None:
         Test.return_value = False
         Test.tests = [
-            RuleTest(name="test", expected_result=True, log={}),
-            RuleTest(name="test", expected_result=False, log={}),
+            RuleTest(name="test1", expected_result=True, log={}),
+            RuleTest(name="test2", expected_result=False, log={}),
         ]
         testing.print_rule_test_results(False, Test.id, Test.run_tests(get_data_model))
 
         exp = (
             "\x1b[95mTest\x1b[0m:\n"
-            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test\n"
+            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test2\n"
             "     - Expected rule() to return 'True', but got 'False'\n"
             "\n"
         )
@@ -175,14 +175,14 @@ class TestPrintRuleTestResults:
     def test_both_pass_and_fail_verbose(self, capsys) -> None:
         Test.return_value = False
         Test.tests = [
-            RuleTest(name="test", expected_result=True, log={}),
-            RuleTest(name="test", expected_result=False, log={}),
+            RuleTest(name="test1", expected_result=True, log={}),
+            RuleTest(name="test2", expected_result=False, log={}),
         ]
         testing.print_rule_test_results(True, Test.id, Test.run_tests(get_data_model))
 
         exp = (
             "\x1b[95mTest\x1b[0m:\n"
-            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test\n"
+            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test2\n"
             "     - Expected rule() to return 'True', but got 'False'\n"
             "   \x1b[92mPASS\x1b[0m: test\n"
             "\n"

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -164,7 +164,7 @@ class TestPrintRuleTestResults:
 
         exp = (
             "\x1b[95mTest\x1b[0m:\n"
-            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test2\n"
+            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test1\n"
             "     - Expected rule() to return 'True', but got 'False'\n"
             "\n"
         )
@@ -182,9 +182,9 @@ class TestPrintRuleTestResults:
 
         exp = (
             "\x1b[95mTest\x1b[0m:\n"
-            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test2\n"
+            "   \x1b[1m\x1b[91mFAIL\x1b[0m\x1b[0m: test1\n"
             "     - Expected rule() to return 'True', but got 'False'\n"
-            "   \x1b[92mPASS\x1b[0m: test\n"
+            "   \x1b[92mPASS\x1b[0m: test2\n"
             "\n"
         )
         std = capsys.readouterr()


### PR DESCRIPTION
### Description

In case a rule has multiple tests with the same name, `pypanther test` should fail. The check was already present in the BE and was blocking `pypanther upload`


### Checklist

- [x] Added unit tests
- [x] Tested end to end, including screenshots or videos
<img width="867" alt="Screenshot 2025-04-01 at 11 22 02" src="https://github.com/user-attachments/assets/c48adea9-c7b2-4739-a91e-b7062816a0fd" />



### Notes for Reviewing

Testing steps to help reviewers test code. Include any Feature Flags or Pulumi Configs needed to test.
