### PR TITLE
Migrate dac-bot to panther-bot-automation

### DIFF
--- a/.github/workflows/sync-pa.yml
+++ b/.github/workflows/sync-pa.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Check out this repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
@@ -46,12 +48,19 @@ jobs:
         poetry run ruff check --output-format=github .
         poetry run ruff format --check .
         poetry run mypy .
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # 6.3.0
+      with:
+        gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY_PASSPHRASE }}
+        git_user_signingkey: true
+        git_commit_gpgsign: true
     - name: Create PR
       env:
         GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
       run: |
-        git config user.name "dac-bot[bot]"
-        git config user.email "dac-bot@panther.com"
+        git config --global user.email "github-service-account-automation@panther.io"
+        git config --global user.name "panther-bot-automation"  
         git add .
         git commit -a -m "sync panther-analysis release"
         git checkout -b sync-panther-analysis-release

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -21,10 +22,17 @@ jobs:
       - name: Install Requirements
         run: |
           pip install --upgrade pip poetry
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # 6.3.0
+        with:
+          gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Set up Git
         run: |
-          git config user.name "dac-bot[bot]"
-          git config user.email "dac-bot@panther.com"
+          git config --global user.email "github-service-account-automation@panther.io"
+          git config --global user.name "panther-bot-automation"  
       - name: Check and update tag
         run: |
           VERSION="v$(poetry version --short)"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           fetch-depth: 0
+          token: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -32,14 +33,21 @@ jobs:
         run: echo "old_version=$(poetry version --short)" >> $GITHUB_OUTPUT
       - name: Bump version
         run: poetry version "${{ github.event.inputs.bump_type }}"
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # 6.3.0
+        with:
+          gpg_private_key: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PANTHER_BOT_GPG_PRIVATE_KEY_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Create Branch and Pull Request
         env:
           GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}
         run: |
           NEW_VERSION="$(poetry version --short)"
           OLD_VERSION="${{ steps.collect_old_version.outputs.old_version }}"
-          git config user.name "dac-bot[bot]"
-          git config user.email "dac-bot@panther.com"
+          git config --global user.email "github-service-account-automation@panther.io"
+          git config --global user.name "panther-bot-automation"  
           git checkout -b "$NEW_VERSION"
           git commit -a -m "Bump version to $NEW_VERSION"
           git push --set-upstream origin "$NEW_VERSION"


### PR DESCRIPTION
### Description

The CLA check is currently failing on some PRs due to the name being under "dac-bot[bot]" instead of "panther-bot-automation". I migrated our git setup/signing logic to hopefully standardize this.

### References

JIRA Ticket Link:

### Checklist

- [ ] Added unit tests
- [ ] Tested end to end, including screenshots or videos

### Notes for Reviewing

Testing steps to help reviewers test code. Include any Feature Flags or Pulumi Configs needed to test.
